### PR TITLE
feat: set keyboard shortcut to open regex match window

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   "contributes": {
     "commands": [
       {
-        "command": "regex-match.openRegexTestWindow",
-        "title": "Regex Match: Open Regex Test Window"
+        "command": "regex-match.openRegexMatchWindow",
+        "title": "Regex Match: Open Regex Match Window"
       }
     ],
     "keybindings": {
-      "command": "regex-match.openRegexTestWindow",
+      "command": "regex-match.openRegexMatchWindow",
       "key": "ctrl+alt+x",
       "mac": "cmd+alt+x"
     }

--- a/src/RegexMatchService.ts
+++ b/src/RegexMatchService.ts
@@ -24,7 +24,7 @@ class RegexMatchService {
   }
 
   registerCommands(): Disposable[] {
-    const openRegexTextCommand = commands.registerCommand('regex-match.openRegexTestWindow', () =>
+    const openRegexTextCommand = commands.registerCommand('regex-match.openRegexMatchWindow', () =>
       this.openRegexTestWindow(),
     );
 

--- a/src/tests/integration/regex-test-window.test.ts
+++ b/src/tests/integration/regex-test-window.test.ts
@@ -7,7 +7,7 @@ import { REGEX_TEST_FILE_PATH } from '@/RegexMatchService';
 
 describe('Regex Test Window', () => {
   it('should open the regex test window by command with correct content', async () => {
-    await commands.executeCommand('regex-match.openRegexTestWindow');
+    await commands.executeCommand('regex-match.openRegexMatchWindow');
     const activeTextEditor = window.activeTextEditor;
 
     assert.notStrictEqual(activeTextEditor, undefined);


### PR DESCRIPTION
### Features

- Set `Ctrl + Alt + X` as keyboard shortcut to open regex match window

### Chore

- Changed command name from `Open Regex Test Window` to `Open Regex Match Window`

---
Closes #11 