### PR TITLE
feat: report errors with diagnostics (#27) 

### DIFF
--- a/src/DiagnosticProvider.ts
+++ b/src/DiagnosticProvider.ts
@@ -1,0 +1,29 @@
+import { Diagnostic, DiagnosticCollection, DiagnosticSeverity, Range, Uri, languages } from 'vscode';
+
+class DiagnosticProvider {
+  private diagnosticCollection: DiagnosticCollection;
+
+  constructor(diagnosticCollectionName: string) {
+    this.diagnosticCollection = languages.createDiagnosticCollection(diagnosticCollectionName);
+  }
+
+  getDiagnosticCollection() {
+    return this.diagnosticCollection;
+  }
+
+  createErrorDiagnostic(range: Range, message: string) {
+    const errorDiagnostic = new Diagnostic(range, message, DiagnosticSeverity.Error);
+    return errorDiagnostic;
+  }
+
+  createWarningDiagnostic(range: Range, message: string) {
+    const warningDiagnostic = new Diagnostic(range, message, DiagnosticSeverity.Warning);
+    return warningDiagnostic;
+  }
+
+  updateDiagnostics(uri: Uri, diagnostics: Diagnostic[]) {
+    this.diagnosticCollection.set(uri, diagnostics);
+  }
+}
+
+export default DiagnosticProvider;

--- a/src/FileParser.ts
+++ b/src/FileParser.ts
@@ -13,15 +13,33 @@ class FileParser {
   static parseFileContent(fileContent: string): ParsedRegexTest | undefined {
     const fileLines = fileContent.split('\n');
 
-    if (fileLines.length > 0) {
-      const matchingRegex = this.transformStringToRegExp(fileLines[0]);
+    const firstDelimiterLineIndex = this.findFirstDelimiterLineIndex(fileLines);
+    if (
+      firstDelimiterLineIndex === undefined ||
+      firstDelimiterLineIndex === fileLines.length - 1 ||
+      firstDelimiterLineIndex === 0
+    ) {
+      return undefined;
+    }
 
-      if (matchingRegex) {
-        const testLines = this.getTestLines(fileLines.slice(1), matchingRegex.multiline);
+    const regexLine = fileLines[firstDelimiterLineIndex - 1];
+    const matchingRegex = this.transformStringToRegExp(regexLine);
 
-        const startTestIndex = fileContent.indexOf(TEST_AREA_DELIMITER) + TEST_AREA_DELIMITER.length + 1;
+    if (!matchingRegex) {
+      return undefined;
+    }
 
-        return { matchingRegex, testLines, startTestIndex };
+    const testLines = this.getTestLines(fileLines.slice(firstDelimiterLineIndex), matchingRegex.multiline);
+
+    const startTestIndex = fileContent.indexOf(TEST_AREA_DELIMITER) + TEST_AREA_DELIMITER.length + 1;
+
+    return { matchingRegex, testLines, startTestIndex };
+  }
+
+  static findFirstDelimiterLineIndex(fileLines: string[]): number | undefined {
+    for (let i = 0; i < fileLines.length; i++) {
+      if (this.isTestAreaDelimiter(fileLines[i])) {
+        return i;
       }
     }
   }
@@ -55,6 +73,10 @@ class FileParser {
     }
 
     return [testLines.join('\n')];
+  }
+
+  private static isTestAreaDelimiter(line: string): boolean {
+    return line === TEST_AREA_DELIMITER;
   }
 }
 

--- a/src/RegexMatchService.ts
+++ b/src/RegexMatchService.ts
@@ -19,14 +19,14 @@ import RegexTester from './RegexTester';
 
 export const REGEX_TEST_FILE_PATH = '/regex-test-file/RegexMatch.rgx';
 
-const REGEX_TEST_PATTERN_ERROR_MESSAGE = `Parsing error: The format of the regex test is incorrect. Please ensure your test follows the required pattern.\n\nExpected format:\n\n1 /regex/[flags]\n2 ---\n3 test string\n4 ---`;
+const REGEX_TEST_PATTERN_ERROR_MESSAGE = `Parsing error: The format of the regex test is incorrect. Please ensure your test follows the required pattern.\n\nExpected format:\n\n/regex/[flags]\n---\ntest string\n---`;
 
 class RegexMatchService {
   private regexTestFileUri: Uri;
   private diagnosticProvider: DiagnosticProvider;
 
   constructor(context: ExtensionContext) {
-    this.regexTestFileUri = Uri.file(`${context.extensionPath}/${REGEX_TEST_FILE_PATH}`);
+    this.regexTestFileUri = Uri.file(`${context.extensionPath}${REGEX_TEST_FILE_PATH}`);
     this.diagnosticProvider = new DiagnosticProvider('regex-match');
   }
 
@@ -104,14 +104,15 @@ class RegexMatchService {
 
   private onChangeTextDocument(event: TextDocumentChangeEvent) {
     const activeEditor = window.activeTextEditor;
-    if (!activeEditor) {
-      return;
-    }
+    const eventDocument = event.document;
 
-    const document = event.document;
-
-    if (document === activeEditor.document && event.contentChanges.length !== 0) {
-      this.updateRegexTest(document);
+    if (
+      activeEditor &&
+      eventDocument.uri.path === this.regexTestFileUri.path &&
+      eventDocument === activeEditor.document &&
+      event.contentChanges.length > 0
+    ) {
+      this.updateRegexTest(eventDocument);
     }
   }
 }

--- a/src/RegexTester.ts
+++ b/src/RegexTester.ts
@@ -1,5 +1,7 @@
 import { ParsedRegexTest } from './FileParser';
 
+const NEW_LINE_LENGTH = 1;
+
 export interface MatchResult {
   substring: string;
   range: number[];
@@ -28,7 +30,7 @@ class RegexTester {
         }
       }
 
-      lineStartIndex += line.length + 1;
+      lineStartIndex += line.length + NEW_LINE_LENGTH;
     }
 
     return matchResults;

--- a/src/RegexTester.ts
+++ b/src/RegexTester.ts
@@ -16,15 +16,12 @@ class RegexTester {
       let match: RegExpExecArray | null;
 
       while ((match = matchingRegex.exec(line)) !== null) {
-        const range = [lineStartIndex + match.index, lineStartIndex + match.index + match[0].length];
-
-        let groupRanges: number[][] | undefined;
-        if (match.indices && match.indices.length > 1) {
-          const matchGroupIndexes = match.indices.slice(1);
-          groupRanges = this.getGroupRanges(matchGroupIndexes, lineStartIndex);
+        if (match[0].trim() === '') {
+          break;
         }
 
-        matchResults.push({ substring: match[0], range, groupRanges });
+        const processedMatch = this.processMatch(match, lineStartIndex);
+        matchResults.push(processedMatch);
 
         if (!matchingRegex.global) {
           break;
@@ -35,6 +32,18 @@ class RegexTester {
     }
 
     return matchResults;
+  }
+
+  static processMatch(match: RegExpExecArray, lineStartIndex: number): MatchResult {
+    const range = [lineStartIndex + match.index, lineStartIndex + match.index + match[0].length];
+
+    let groupRanges: number[][] | undefined;
+    if (match.indices && match.indices.length > 1) {
+      const matchGroupIndexes = match.indices.slice(1);
+      groupRanges = this.getGroupRanges(matchGroupIndexes, lineStartIndex);
+    }
+
+    return { substring: match[0], range, groupRanges };
   }
 
   static getGroupRanges(matchIndexes: (number[] | undefined)[], startIndex: number): number[][] {

--- a/src/decorations/TextDecorationApplier.ts
+++ b/src/decorations/TextDecorationApplier.ts
@@ -13,10 +13,10 @@ class TextDecorationApplier {
     }
 
     this.resetDecorations(activeEditor);
+    this.applyDelimiterDecorations(activeEditor);
 
     if (matchResults) {
       this.applyMatchDecorations(activeEditor, matchResults);
-      this.applyDelimiterDecorations(activeEditor);
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ export function activate(context: ExtensionContext) {
 
   const regexMatchCommands = regexMatchService.registerCommands();
   const regexMatchDisposables = regexMatchService.registerDisposables();
-  const diagnosticCollection = regexMatchService.createDiagnosticCollection();
+  const diagnosticCollection = regexMatchService.getDiagnosticCollection();
 
   context.subscriptions.push(...regexMatchCommands, ...regexMatchDisposables, diagnosticCollection);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ export function activate(context: ExtensionContext) {
 
   const regexMatchCommands = regexMatchService.registerCommands();
   const regexMatchDisposables = regexMatchService.registerDisposables();
+  const diagnosticCollection = regexMatchService.createDiagnosticCollection();
 
-  context.subscriptions.push(...regexMatchCommands, ...regexMatchDisposables);
+  context.subscriptions.push(...regexMatchCommands, ...regexMatchDisposables, diagnosticCollection);
 }

--- a/src/tests/unit/file-parser.test.ts
+++ b/src/tests/unit/file-parser.test.ts
@@ -69,4 +69,28 @@ describe('File Parser', () => {
 
     expect(() => FileParser.parseFileContent(fileContent)).toThrowError();
   });
+
+  it('should return undefined if the file content does not contain the test area delimiter', () => {
+    const fileContent = '/[0-9]a/g\nbb9abb\n---';
+
+    const parsedRegexTest = FileParser.parseFileContent(fileContent);
+
+    expect(parsedRegexTest).toBeUndefined();
+  });
+
+  it('should return undefined if the file content does not contain the matching regex', () => {
+    const fileContent = '---\nbb9abb\n---';
+
+    const parsedRegexTest = FileParser.parseFileContent(fileContent);
+
+    expect(parsedRegexTest).toBeUndefined();
+  });
+
+  it('should return undefined if the file content does not contain the test area', () => {
+    const fileContent = '/[0-9]a/g\n---';
+
+    const parsedRegexTest = FileParser.parseFileContent(fileContent);
+
+    expect(parsedRegexTest).toBeUndefined();
+  });
 });

--- a/src/tests/unit/regex-tester.test.ts
+++ b/src/tests/unit/regex-tester.test.ts
@@ -153,6 +153,19 @@ describe('Regex Tester', () => {
     expect(matchResult[2].groupRanges).toBeUndefined();
   });
 
+  it('should test regex correctly, if the regex is empty', () => {
+    const regex = new RegExp('', 'gm');
+
+    const parsedRegexTest: ParsedRegexTest = {
+      matchingRegex: regex,
+      testLines: ['9ab', '8a', '7A'],
+      startTestIndex: 0,
+    };
+
+    const matchResult = RegexTester.testRegex(parsedRegexTest);
+    expect(matchResult.length).toBe(0);
+  });
+
   describe('Capturing Groups', () => {
     it('should extract capturing group ranges', () => {
       const regex = new RegExp('[0-9]ax(abc)', 'gmd');

--- a/src/tests/unit/regex-tester.test.ts
+++ b/src/tests/unit/regex-tester.test.ts
@@ -128,6 +128,31 @@ describe('Regex Tester', () => {
     expect(matchResult[2].groupRanges).toBeUndefined();
   });
 
+  it('should test regex correctly, if there is a flag other than defaults', () => {
+    const regex = new RegExp('[0-9]a', 'i');
+
+    const parsedRegexTest: ParsedRegexTest = {
+      matchingRegex: regex,
+      testLines: ['9ab', '8a', '7A'],
+      startTestIndex: 0,
+    };
+
+    const matchResult = RegexTester.testRegex(parsedRegexTest);
+    expect(matchResult.length).toBe(3);
+
+    expect(matchResult[0].substring).toBe('9a');
+    expect(matchResult[0].range).toEqual([0, 2]);
+    expect(matchResult[0].groupRanges).toBeUndefined();
+
+    expect(matchResult[1].substring).toBe('8a');
+    expect(matchResult[1].range).toEqual([4, 6]);
+    expect(matchResult[1].groupRanges).toBeUndefined();
+
+    expect(matchResult[2].substring).toBe('7A');
+    expect(matchResult[2].range).toEqual([7, 9]);
+    expect(matchResult[2].groupRanges).toBeUndefined();
+  });
+
   describe('Capturing Groups', () => {
     it('should extract capturing group ranges', () => {
       const regex = new RegExp('[0-9]ax(abc)', 'gmd');


### PR DESCRIPTION
### Features

- Report errors with `Diagnostics`.
- Fixed the format of the regex test with the regexp being on the previous line of the first delimiter.

### Fixes

- Accept empty regex.
- Only runs the `updateRegexTest` function and decoration applications when the changed document is the Regex Match file.

### Tests

- Created test for regex testing with flag different from the defaults.
- Created tests for regex testing with empty regex.
- Created tests for undefined return cases of file parser.

### Screenshots
![image](https://github.com/pedrohenrique-ql/vscode-regex-match/assets/62706751/69ad6561-9e58-4c37-a9f8-51e3aac252f4)
![image](https://github.com/pedrohenrique-ql/vscode-regex-match/assets/62706751/01f74b0e-b516-4661-bbae-2acf4b29d786)

---
Closes #27 