### PR TITLE
fix: regex test with new line character (#32)

### DIFF
--- a/src/RegexTest.ts
+++ b/src/RegexTest.ts
@@ -57,7 +57,7 @@ class RegexTest {
 
   private transformStringToRegExp(regexPattern: string, regexLineIndex: number): RegExp | undefined {
     try {
-      const matchGroups = regexPattern.match(/^\/?(.*?)(?<flags>\/[igmsuy]*)?$/i);
+      const matchGroups = regexPattern.match(/^\/?(.*?)(?<flags>\/[igmsuy]*)?$/);
 
       if (matchGroups) {
         const [, pattern] = matchGroups;

--- a/src/tests/unit/file-parser.test.ts
+++ b/src/tests/unit/file-parser.test.ts
@@ -14,8 +14,8 @@ describe('File Parser', () => {
     expect(regexTests).toHaveLength(1);
 
     expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]a/dg);
-    expect(regexTests[0].getTestLines()).toHaveLength(1);
-    expect(regexTests[0].getTestLines()[0]).toBe('bb9abb');
+    expect(regexTests[0].getFormattedTestString()).toHaveLength(1);
+    expect(regexTests[0].getFormattedTestString()[0]).toBe('bb9abb');
     expect(regexTests[0].getStartTestIndex()).toBe(14);
   });
 
@@ -27,9 +27,9 @@ describe('File Parser', () => {
     expect(regexTests).toHaveLength(1);
 
     expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]a/dgm);
-    expect(regexTests[0].getTestLines()).toHaveLength(2);
-    expect(regexTests[0].getTestLines()[0]).toBe('bb9abb');
-    expect(regexTests[0].getTestLines()[1]).toBe('2a');
+    expect(regexTests[0].getFormattedTestString()).toHaveLength(2);
+    expect(regexTests[0].getFormattedTestString()[0]).toBe('bb9abb');
+    expect(regexTests[0].getFormattedTestString()[1]).toBe('2a');
     expect(regexTests[0].getStartTestIndex()).toBe(15);
   });
 
@@ -41,8 +41,9 @@ describe('File Parser', () => {
     expect(regexTests).toHaveLength(1);
 
     expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]a/dg);
-    expect(regexTests[0].getTestLines()).toHaveLength(1);
-    expect(regexTests[0].getTestLines()[0]).toBe('bb9abb\n2a');
+    expect(regexTests[0].getFormattedTestString()).toHaveLength(2);
+    expect(regexTests[0].getFormattedTestString()[0]).toBe('bb9abb');
+    expect(regexTests[0].getFormattedTestString()[1]).toBe('2a');
     expect(regexTests[0].getStartTestIndex()).toBe(14);
   });
 
@@ -54,8 +55,8 @@ describe('File Parser', () => {
     expect(regexTests).toHaveLength(1);
 
     expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]a/dgm);
-    expect(regexTests[0].getTestLines()).toHaveLength(1);
-    expect(regexTests[0].getTestLines()[0]).toBe('bb9abb');
+    expect(regexTests[0].getFormattedTestString()).toHaveLength(1);
+    expect(regexTests[0].getFormattedTestString()[0]).toBe('bb9abb');
     expect(regexTests[0].getStartTestIndex()).toBe(15);
   });
 
@@ -173,15 +174,15 @@ describe('File Parser', () => {
       expect(regexTests).toHaveLength(2);
 
       expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
-      expect(regexTests[0].getTestLines()).toHaveLength(2);
-      expect(regexTests[0].getTestLines()[0]).toBe('test1');
-      expect(regexTests[0].getTestLines()[1]).toBe('test2');
+      expect(regexTests[0].getFormattedTestString()).toHaveLength(2);
+      expect(regexTests[0].getFormattedTestString()[0]).toBe('test1');
+      expect(regexTests[0].getFormattedTestString()[1]).toBe('test2');
       expect(regexTests[0].getStartTestIndex()).toBe(14);
 
       expect(regexTests[1].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
-      expect(regexTests[1].getTestLines()).toHaveLength(2);
-      expect(regexTests[1].getTestLines()[0]).toBe('test3');
-      expect(regexTests[1].getTestLines()[1]).toBe('test4');
+      expect(regexTests[1].getFormattedTestString()).toHaveLength(2);
+      expect(regexTests[1].getFormattedTestString()[0]).toBe('test3');
+      expect(regexTests[1].getFormattedTestString()[1]).toBe('test4');
       expect(regexTests[1].getStartTestIndex()).toBe(44);
     });
 
@@ -193,14 +194,15 @@ describe('File Parser', () => {
       expect(regexTests).toHaveLength(2);
 
       expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
-      expect(regexTests[0].getTestLines()).toHaveLength(2);
-      expect(regexTests[0].getTestLines()[0]).toBe('test1');
-      expect(regexTests[0].getTestLines()[1]).toBe('test2');
+      expect(regexTests[0].getFormattedTestString()).toHaveLength(2);
+      expect(regexTests[0].getFormattedTestString()[0]).toBe('test1');
+      expect(regexTests[0].getFormattedTestString()[1]).toBe('test2');
       expect(regexTests[0].getStartTestIndex()).toBe(14);
 
       expect(regexTests[1].getMatchingRegex()).toStrictEqual(/[0-9]/di);
-      expect(regexTests[1].getTestLines()).toHaveLength(1);
-      expect(regexTests[1].getTestLines()[0]).toBe('test3\ntest4');
+      expect(regexTests[1].getFormattedTestString()).toHaveLength(2);
+      expect(regexTests[1].getFormattedTestString()[0]).toBe('test3');
+      expect(regexTests[1].getFormattedTestString()[1]).toBe('test4');
       expect(regexTests[1].getStartTestIndex()).toBe(43);
     });
 
@@ -227,15 +229,15 @@ describe('File Parser', () => {
       expect(regexTests).toHaveLength(2);
 
       expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
-      expect(regexTests[0].getTestLines()).toHaveLength(2);
-      expect(regexTests[0].getTestLines()[0]).toBe('test1');
-      expect(regexTests[0].getTestLines()[1]).toBe('test2');
+      expect(regexTests[0].getFormattedTestString()).toHaveLength(2);
+      expect(regexTests[0].getFormattedTestString()[0]).toBe('test1');
+      expect(regexTests[0].getFormattedTestString()[1]).toBe('test2');
       expect(regexTests[0].getStartTestIndex()).toBe(14);
 
       expect(regexTests[1].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
-      expect(regexTests[1].getTestLines()).toHaveLength(2);
-      expect(regexTests[1].getTestLines()[0]).toBe('test3');
-      expect(regexTests[1].getTestLines()[1]).toBe('test4');
+      expect(regexTests[1].getFormattedTestString()).toHaveLength(2);
+      expect(regexTests[1].getFormattedTestString()[0]).toBe('test3');
+      expect(regexTests[1].getFormattedTestString()[1]).toBe('test4');
       expect(regexTests[1].getStartTestIndex()).toBe(46);
     });
   });

--- a/src/tests/unit/regex-test.test.ts
+++ b/src/tests/unit/regex-test.test.ts
@@ -65,7 +65,7 @@ describe('Regex Test', () => {
     expect(matchResult.length).toBe(0);
   });
 
-  it('should test regex correctly, if there are many test lines and has multine flag', () => {
+  it('should test regex correctly, if there are many test lines and has multiline flag', () => {
     const regexTestProps: RegexTestProps = {
       regexPattern: '/^[0-9]a/gm',
       regexLineIndex: 0,

--- a/src/tests/unit/regex-test.test.ts
+++ b/src/tests/unit/regex-test.test.ts
@@ -86,7 +86,7 @@ describe('Regex Test', () => {
     expect(matchResult[1].groupRanges).toBeUndefined();
   });
 
-  it('should test regex correctly, if there are many test lines and does not have multine flag', () => {
+  it('should test regex correctly, if there are many test lines and does not have multiline flag', () => {
     const regexTestProps: RegexTestProps = {
       regexPattern: '/^[0-9]a/g',
       regexLineIndex: 0,
@@ -189,6 +189,23 @@ describe('Regex Test', () => {
     expect(matchResult[2].substring).toBe('7A');
     expect(matchResult[2].range).toEqual([7, 9]);
     expect(matchResult[2].groupRanges).toBeUndefined();
+  });
+
+  it('should test regex correctly, if the regex has a new line character', () => {
+    const regexTestProps: RegexTestProps = {
+      regexPattern: '/[0-9]a\\n\\d{3}b/gm',
+      regexLineIndex: 0,
+      testLines: ['9a', '123b', '7A'],
+      startTestIndex: 0,
+    };
+
+    const regexTest = new RegexTest(regexTestProps);
+    const matchResult = regexTest.test();
+    expect(matchResult.length).toBe(1);
+
+    expect(matchResult[0].substring).toBe('9a\n123b');
+    expect(matchResult[0].range).toEqual([0, 7]);
+    expect(matchResult[0].groupRanges).toBeUndefined();
   });
 
   it('should throw an error, if the regex is invalid', () => {

--- a/src/tests/unit/regex-test.test.ts
+++ b/src/tests/unit/regex-test.test.ts
@@ -166,6 +166,31 @@ describe('Regex Test', () => {
     expect(matchResult.length).toBe(0);
   });
 
+  it('should test regex correctly, if the regex is a wildcard regex', () => {
+    const regexTestProps: RegexTestProps = {
+      regexPattern: '/.*/gm',
+      regexLineIndex: 0,
+      testLines: ['9ab', '8a', '7A'],
+      startTestIndex: 0,
+    };
+
+    const regexTest = new RegexTest(regexTestProps);
+    const matchResult = regexTest.test();
+    expect(matchResult.length).toBe(3);
+
+    expect(matchResult[0].substring).toBe('9ab');
+    expect(matchResult[0].range).toEqual([0, 3]);
+    expect(matchResult[0].groupRanges).toBeUndefined();
+
+    expect(matchResult[1].substring).toBe('8a');
+    expect(matchResult[1].range).toEqual([4, 6]);
+    expect(matchResult[1].groupRanges).toBeUndefined();
+
+    expect(matchResult[2].substring).toBe('7A');
+    expect(matchResult[2].range).toEqual([7, 9]);
+    expect(matchResult[2].groupRanges).toBeUndefined();
+  });
+
   it('should throw an error, if the regex is invalid', () => {
     const regexTestProps: RegexTestProps = {
       regexPattern: '/(?/gm',


### PR DESCRIPTION
### Fixes

- Fixed regex test when has new line character.
- Fixed the regex test for patterns using the wildcard regex `.*`.

### Screenshots
#### New line character
![image](https://github.com/pedrohenrique-ql/vscode-regex-match/assets/62706751/531f9694-3971-4f30-b7e7-fd79db493243)

#### Wildcard regex
![image](https://github.com/pedrohenrique-ql/vscode-regex-match/assets/62706751/c94acb42-cced-4e2e-8f05-3f8650547b23)

---
Closes #32.