### PR TITLE
feat: create configuration to enable/disable code lens (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.0
 
 - Added the functionality to test regex present in the code editor in the regex match window.
+- Created configuration settings to enable/disable the code lens feature.
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=pedrohenrique-ql.regex-match">
     <img alt="Visual Studio Marketplace Version" src="https://img.shields.io/visual-studio-marketplace/v/pedrohenrique-ql.regex-match?logo=visualstudiocode&logoColor=007acc&label=VS%20Marketplace&labelColor=2c2c32&color=007acc"></a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=pedrohenrique-ql.regex-match">
-    <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/pedrohenrique-ql/vscode-regex-match/ci.yaml?branch=canary&logo=github&label=CI&labelColor=2c2c32"></a>
   <a href="https://github.com/pedrohenrique-ql/vscode-regex-match/actions?query=branch%3Acanary">
+    <img alt="GitHub Actions Workflow Status" src="https://img.shields.io/github/actions/workflow/status/pedrohenrique-ql/vscode-regex-match/ci.yaml?branch=canary&logo=github&label=CI&labelColor=2c2c32"></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=pedrohenrique-ql.regex-match">
     <img alt="Visual Studio Marketplace Installs" src="https://img.shields.io/visual-studio-marketplace/i/pedrohenrique-ql.regex-match?logo=visualstudiocode&logoColor=007acc&label=Installs&labelColor=2c2c32&color=007acc"></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=pedrohenrique-ql.regex-match">
     <img alt="Visual Studio Marketplace Downloads" src="https://img.shields.io/visual-studio-marketplace/d/pedrohenrique-ql.regex-match?logo=visualstudiocode&logoColor=007acc&label=Downloads&labelColor=2c2c32&color=007acc"></a>

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Through VS Code's code lens functionality, Regex Match makes it easy to test the
 
 - Enables multiple regex testing in the regex match window.
 - Correction of regex testing with `\n` and wildcard character.
-- Created configuration settings to enable/disable the code lens feature.
 
 ### 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,16 @@ Through VS Code's code lens functionality, Regex Match makes it easy to test the
 
 ## 📝 Release Notes
 
+## 0.4.0
+
+- Added the functionality to test regex present in the code editor in the regex match window.
+- Created configuration settings to enable/disable the code lens feature.
+
 ### 0.3.0
 
 - Enables multiple regex testing in the regex match window.
 - Correction of regex testing with `\n` and wildcard character.
+- Created configuration settings to enable/disable the code lens feature.
 
 ### 0.2.0
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,17 @@
       "command": "regex-match.openRegexMatchWindow",
       "key": "ctrl+alt+x",
       "mac": "cmd+alt+x"
+    },
+    "configuration": {
+      "type": "object",
+      "title": "Regex Match",
+      "properties": {
+        "regex-match.codeLens.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable the code lens that allows you to test the regex from code editor."
+        }
+      }
     }
   },
   "scripts": {

--- a/src/RegexMatchService.ts
+++ b/src/RegexMatchService.ts
@@ -1,4 +1,6 @@
 import {
+  CodeLensProvider,
+  ConfigurationChangeEvent,
   Diagnostic,
   Disposable,
   ExtensionContext,
@@ -7,10 +9,12 @@ import {
   TextDocumentChangeEvent,
   Uri,
   commands,
+  languages,
   window,
   workspace,
 } from 'vscode';
 
+import TestRegexCodeLensProvider from './code-lenses/TestRegexCodeLensProvider';
 import TextDecorationApplier from './decorations/TextDecorationApplier';
 import DiagnosticProvider from './DiagnosticProvider';
 import RegexMatchFormatError from './exceptions/RegexMatchFormatError';
@@ -21,12 +25,21 @@ import FileParser from './FileParser';
 export const REGEX_TEST_FILE_PATH = '/regex-test-file/RegexMatch.rgx';
 
 class RegexMatchService {
+  private context: ExtensionContext;
+
   private regexTestFileUri: Uri;
   private diagnosticProvider: DiagnosticProvider;
 
+  private testRegexCodeLensProvider: CodeLensProvider;
+  private codeLensDisposable: Disposable | undefined;
+
   constructor(context: ExtensionContext) {
+    this.context = context;
     this.regexTestFileUri = Uri.file(`${context.extensionPath}${REGEX_TEST_FILE_PATH}`);
     this.diagnosticProvider = new DiagnosticProvider('regex-match');
+    this.testRegexCodeLensProvider = new TestRegexCodeLensProvider();
+
+    this.updateCodeLensProvider();
   }
 
   registerCommands(): Disposable[] {
@@ -39,8 +52,11 @@ class RegexMatchService {
 
   registerDisposables(): Disposable[] {
     const onChangeTextDocumentDisposable = this.setupTextDocumentChangeHandling();
+    const onChangeConfigurationDisposable = workspace.onDidChangeConfiguration((event) =>
+      this.onChangeConfiguration(event),
+    );
 
-    return [onChangeTextDocumentDisposable];
+    return [onChangeTextDocumentDisposable, onChangeConfigurationDisposable];
   }
 
   getDiagnosticCollection() {
@@ -108,6 +124,30 @@ class RegexMatchService {
       event.contentChanges.length > 0
     ) {
       this.updateRegexTest(eventDocument);
+    }
+  }
+
+  private onChangeConfiguration(event: ConfigurationChangeEvent) {
+    if (event.affectsConfiguration('regex-match.codeLens.enabled')) {
+      this.updateCodeLensProvider();
+    }
+  }
+
+  private updateCodeLensProvider() {
+    const isCodeLensEnabled = workspace.getConfiguration('regex-match').get<boolean>('codeLens.enabled');
+
+    if (isCodeLensEnabled) {
+      if (!this.codeLensDisposable) {
+        this.codeLensDisposable = languages.registerCodeLensProvider(
+          { pattern: '**/*' },
+          this.testRegexCodeLensProvider,
+        );
+
+        this.context.subscriptions.push(this.codeLensDisposable);
+      }
+    } else if (this.codeLensDisposable) {
+      this.codeLensDisposable.dispose();
+      this.codeLensDisposable = undefined;
     }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,13 @@
-import { ExtensionContext, languages } from 'vscode';
+import { ExtensionContext } from 'vscode';
 
-import TestRegexCodeLensProvider from './code-lenses/TestRegexCodeLensProvider';
 import RegexMatchService from './RegexMatchService';
 
 export function activate(context: ExtensionContext) {
   const regexMatchService = new RegexMatchService(context);
 
-  const codeLens = new TestRegexCodeLensProvider();
-  const codeLensProvider = languages.registerCodeLensProvider({ pattern: '**/*' }, codeLens);
-
   const regexMatchCommands = regexMatchService.registerCommands();
   const regexMatchDisposables = regexMatchService.registerDisposables();
   const diagnosticCollection = regexMatchService.getDiagnosticCollection();
 
-  context.subscriptions.push(...regexMatchCommands, ...regexMatchDisposables, diagnosticCollection, codeLensProvider);
+  context.subscriptions.push(...regexMatchCommands, ...regexMatchDisposables, diagnosticCollection);
 }


### PR DESCRIPTION
### Features

- Created configuration to enable/disable code lens.
- Enable/disable code lens on change configurations.

### Documentation

- Added v0.4.0 section in `Release Notes`.
- Fixed the badges link.

### Screenshots

![image](https://github.com/pedrohenrique-ql/vscode-regex-match/assets/62706751/134ce35b-a54f-4319-b3a7-2a6eaa3c725f)

---
Closes #50.