### PR TITLE
fix: vscode version in documentation (#62)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,6 +31,10 @@ updates:
         update-types:
           - version-update:semver-major
 
+      - dependency-name: '@types/vscode'
+        update-types:
+          - version-update:semver-minor
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/README.md
+++ b/README.md
@@ -92,9 +92,13 @@ Through VS Code's code lens functionality, Regex Match makes it easy to test the
 
 ### Requirements
 
-- [Node.js v.20.11.0](https://nodejs.org/)
-- [Visual Studio Code v1.87.0](https://code.visualstudio.com/)
-- [pnpm v8.15.3](https://pnpm.io/)
+The following dependencies are required to run the project:
+
+| Dependency                                           | Version           |
+| ---------------------------------------------------- | ----------------- |
+| [Node.js](https://nodejs.org/)                       | >= 20.11.0 && <21 |
+| [Visual Studio Code](https://code.visualstudio.com/) | ^1.19.0           |
+| [pnpm](https://pnpm.io/)                             | 8.15.3            |
 
 ### Usage
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "publisher": "pedrohenrique-ql",
   "engines": {
     "node": ">= 20.11.0 <21",
-    "vscode": "^1.87.0"
+    "vscode": "^1.91.0"
   },
   "license": "MIT",
   "categories": [


### PR DESCRIPTION
### Fixes

- Fixed vscode engine version in the `package.json`.
- Fixed vscode required version in the `README.md`.

### Chore

- Added `@types/vscode` dependency in dependabot ignore list to prevent minor updates.

---
Closes #62.