### PR TITLE
fix: not detect comment started by `/*` as regex (#63)

### DIFF
--- a/src/code-lenses/utils.ts
+++ b/src/code-lenses/utils.ts
@@ -1,5 +1,5 @@
 export const JAVASCRIPT_REGEX_DETECT =
-  /(?<!\/)(?<=[({=:>])\s*\/[^/\r\n][^\r\n]*\/[gimuy]*\s*(?=[}),;\n]|\n|$)(?![^/]*\/\*|\*\/)/g;
+  /(?<!\/)(?<=[({=:>])\s*\/(?!\*)[^/\r\n][^\r\n]*\/[gimuy]*\s*(?=[}),;\n]|\n|$)(?![^/]*\/\*|\*\/)/g;
 
 export const REGEX_DETECTORS_MAP: { [key in string]: RegExp | undefined } = {
   javascript: JAVASCRIPT_REGEX_DETECT,

--- a/src/tests/unit/code-regex-detect.test.ts
+++ b/src/tests/unit/code-regex-detect.test.ts
@@ -93,5 +93,12 @@ describe('Code Regex Detect', () => {
       const matches = regexDetect!.exec(code);
       expect(matches).toBeNull();
     });
+
+    it('should not detect regex in comment started by "/*"', () => {
+      const code = `{/* eslint-disable-next-line jsx-ally-/no-static-element/interactions */}`;
+
+      const matches = regexDetect!.exec(code);
+      expect(matches).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
### Fixes

- Improved Javascript regex detector adding lookahead assertion to not detect comment started by `/*` as regex.

### Tests

- Created test for not detect comment start by `/*` as regex, using eslint-disable as test string.

### Screenshots

![image](https://github.com/user-attachments/assets/69593e89-9252-4a66-a8c7-43e9f426bc16)

---
Closes #63
 