### PR TITLE
ci: avoid release github pipeline running twice

### DIFF
--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*.*.*'
 
 concurrency:
   group: release-github-${{ github.ref_name }}


### PR DESCRIPTION
### CI

- Removed on push tags pattern to avoid release github pipeline running twice.

--- 
Closes #69. 