### PR TITLE
fix: detect two regexes on the same line correctly(#76)

### DIFF
--- a/src/code-lenses/utils.ts
+++ b/src/code-lenses/utils.ts
@@ -1,5 +1,5 @@
 export const JAVASCRIPT_REGEX_DETECT =
-  /(?<!\/)(?<=[({=:>])\s*\/(?!\*)[^/\r\n][^\r\n]*\/[gimuy]*\s*(?=[}),;\n]|\n|$)(?![^/]*\/\*|\*\/)/g;
+  /(?<!\/)(?<=[({=:>])\s*\/(?!\*)[^/\r\n][^\r\n]*?\/[gimuy]*\s*(?=[}),;\n]|\n|$)(?![^/]*\/\*|\*\/)/g;
 
 export const REGEX_DETECTORS_MAP: { [key in string]: RegExp | undefined } = {
   javascript: JAVASCRIPT_REGEX_DETECT,


### PR DESCRIPTION
### Fixes

- Updated Javascript regex detector to detect two regexes on the same line correctly.

### Screenshots

![image](https://github.com/user-attachments/assets/00ea524b-e356-478d-9933-96e92e35d221)

---
Closes #76.