### PR TITLE
ci: fix tag creation of github release pipeline (#78)

### DIFF
--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -26,13 +26,13 @@ jobs:
         id: get-version
         run: |
           version=v$(jq -r '.version' package.json)
-           echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Release to GitHub
         uses: ncipollo/release-action@v1
         with:
-          name: ${{ steps.get_version.outputs.version }}
-          tag: ${{ steps.get_version.outputs.version }}
+          name: ${{ steps.get-version.outputs.version }}
+          tag: ${{ steps.get-version.outputs.version }}
           commit: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           makeLatest: ${{ startsWith(github.ref, 'refs/heads/') && github.ref_name == 'main' }}


### PR DESCRIPTION
### CI

- Fixed output step name of create github release pipeline.

--- 
Closes #78.