### PR TITLE
build: bundle only the required files (#81)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,15 +1,26 @@
+# Node
+node_modules/*
+!node_modules/important-dependency/
+
+# Testing
+*/tests/**
+vitest.config.mjs
+
+# Configuration files
 .vscode/**
-.vscode-test/**
-src/**
+.husky/**
+.github/**
+.prettierignore
+.prettierrc
+.eslintrc
+.eslintignore
+.eslintcache
 .gitignore
-.yarnrc
-vsc-extension-quickstart.md
-**/tsconfig.json
-**/.eslintrc.json
-**/.eslintignore
-**/.prettierrc
-**/.prettierignore
-**/*.map
-**/*.ts
-**/.vscode-test.*
-.github
+.vscode-test.mjs
+.lintstagedrc.js
+pnpm-lock.yaml
+tsconfig.json
+tsup.config.ts
+
+## TS files
+src/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.4.2
+
+- Fixed the regex detector to detect two or more regex in the same line.
+- Fixed packaging to ensure only required files are included in the `.vsix` package.
+
 ## 0.4.1
 
 - Fixed Javascript regex detector to avoid detecting comments starting by `/*`.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Through VS Code's code lens functionality, Regex Match makes it easy to test the
 
 ## 📝 Release Notes
 
+## 0.4.2
+
+- Fixed the regex detector to detect two or more regex in the same line.
+- Fixed packaging to ensure only required files are included in the `.vsix` package.
+
 ## 0.4.1
 
 - Fixed Javascript regex detector to avoid detecting comments starting by `/*`.
@@ -76,22 +81,7 @@ Through VS Code's code lens functionality, Regex Match makes it easy to test the
 - Added the functionality to test regex present in the code editor in the regex match window.
 - Created configuration settings to enable/disable the code lens feature.
 
-### 0.3.0
-
-- Enables multiple regex testing in the regex match window.
-- Correction of regex testing with `\n` and wildcard character.
-
-### 0.2.0
-
-- Highlight capturing groups in the test string.
-- Use diagnostics to show errors in the regex match window.
-- Prevents the extension from acting on non-extension files.
-
-### 0.1.0
-
-- Create, test and debug regular expressions within a text file.
-- Highlight matches in the text.
-- Use `Ctrl+Alt+X`/`Cmd+Alt+X` to open the regex match window.
+View the full [CHANGELOG](./CHANGELOG.md).
 
 ## 🛠️ Development
 

--- a/package.json
+++ b/package.json
@@ -64,8 +64,9 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm run compile",
-    "vscode:deploy": "vsce publish",
-    "compile": "tsup",
+    "vscode:package": "pnpm vsce package --no-dependencies",
+    "vscode:publish": "pnpm vsce publish --no-dependencies",
+    "compile": "pnpm run types:check && tsup",
     "pre:test": "pnpm run compile",
     "test:vsc": "pnpm pre:test && vscode-test",
     "test:vi": "vitest",


### PR DESCRIPTION
### Build

- Fixed packaging to ensure only required files are included in the `.vsix` package.

### Documentation

- Update `CHANGELOG.md` and `README.md`.

---
Closes #81.