### PR TITLE
fix: add missing flags to regex detector (#100)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
       day: sunday
       time: '08:00'
       timezone: America/Sao_Paulo
@@ -38,7 +38,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
       day: sunday
       time: '08:00'
       timezone: America/Sao_Paulo

--- a/src/providers/code-lenses/utils.ts
+++ b/src/providers/code-lenses/utils.ts
@@ -1,5 +1,5 @@
 export const JAVASCRIPT_REGEX_DETECT =
-  /(?<!\/)(?<=[({=:>])\s*\/(?!\*)[^/\r\n][^\r\n]*?\/[gimuy]*\s*(?=[}),;\n]|\n|$)(?![^/]*\/\*|\*\/)/g;
+  /(?<!\/)(?<=[({=:>])\s*\/(?!\*)[^/\r\n][^\r\n]*?\/[gimuysv]*\s*(?=[}),;\n]|\n|$)(?![^/]*\/\*|\*\/)/g;
 
 export const REGEX_DETECTORS_MAP: { [key in string]: RegExp | undefined } = {
   javascript: JAVASCRIPT_REGEX_DETECT,

--- a/src/tests/unit/code-regex-detect.test.ts
+++ b/src/tests/unit/code-regex-detect.test.ts
@@ -125,5 +125,16 @@ describe('Code Regex Detect', () => {
       expect(matches[0][0].trim()).toEqual('/ ./g');
       expect(matches[1][0].trim()).toEqual('/ ,/');
     });
+
+    it.each(['g', 'i', 'm', 'u', 'y', 's', 'v'])(`should detect regex with flag '%s'`, (flag) => {
+      const code = `
+        const regex = /hello/${flag};
+      `;
+
+      const matches = getAllMatches(regexDetect!, code);
+      expect(matches).not.toBeNull();
+      expect(matches).toHaveLength(1);
+      expect(matches[0][0].trim()).toEqual(`/hello/${flag}`);
+    });
   });
 });


### PR DESCRIPTION
### Fixes

- Added `s` and `v` flags to regex detector.

### Tests

- Created tests for detect each regex flag.

### Chore

- Changed dependabot interval to `monthly`.

--- 
Closes #100 