### PR TITLE
feat: create regex test block snippet (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## [v0.5.0]
+## [v0.6.0]
+
+- Created a snippet to insert a regex test block into the regex test file.
+
+## [v0.5.0] - 17/12/2024
 
 - Refactored services to implement disposables, improving resource management and extension stability.
 - Added configurable settings to customize the color highlighting of regex matches.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "categories": [
     "Other",
     "Programming Languages",
+    "Snippets",
     "Testing"
   ],
   "keywords": [
@@ -49,11 +50,30 @@
         "title": "Regex Match: Apply Regex to Code"
       }
     ],
-    "keybindings": {
-      "command": "regex-match.openRegexMatchWindow",
-      "key": "ctrl+alt+x",
-      "mac": "cmd+alt+x"
-    },
+    "snippets": [
+      {
+        "language": "plaintext",
+        "path": "./snippets/snippets.json",
+        "name": "Regex Test Block"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "regex-match.openRegexMatchWindow",
+        "key": "ctrl+alt+x",
+        "mac": "cmd+alt+x"
+      },
+      {
+        "command": "editor.action.insertSnippet",
+        "key": "ctrl+alt+g",
+        "mac": "cmd+alt+g",
+        "when": "editorTextFocus && editorLangId == 'plaintext'",
+        "args": {
+          "langId": "plaintext",
+          "name": "Regex Test Block"
+        }
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "Regex Match",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,0 +1,7 @@
+{
+  "Regex Test Block": {
+    "prefix": "regex",
+    "body": ["/${1:regex}/${2:flags}", "---", "${3:Type the test string here...}", "---"],
+    "description": "Create a regex test block"
+  }
+}

--- a/src/tests/integration/regex-match-window.test.ts
+++ b/src/tests/integration/regex-match-window.test.ts
@@ -11,12 +11,12 @@ import { createTemporaryFile, wait, writeDefaultTestFile } from './utils';
 
 describe('Regex Match Window', () => {
   beforeEach(async () => {
-    writeDefaultTestFile();
+    await writeDefaultTestFile();
     await commands.executeCommand('workbench.action.closeAllEditors');
   });
 
-  after(() => {
-    writeDefaultTestFile();
+  after(async () => {
+    await writeDefaultTestFile();
   });
 
   it('should open the regex test window by command with correct content', async () => {

--- a/src/tests/integration/utils.ts
+++ b/src/tests/integration/utils.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { writeFile } from 'fs/promises';
 import path from 'path';
 import { Uri } from 'vscode';
 
@@ -9,9 +10,10 @@ export function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function writeDefaultTestFile() {
+export async function writeDefaultTestFile() {
   const filePath: string = path.join(__dirname, `../../../${REGEX_TEST_FILE_PATH}`);
-  fs.writeFileSync(filePath, DEFAULT_FILE_CONTENT);
+  await writeFile(filePath, DEFAULT_FILE_CONTENT);
+  await wait(100);
 }
 
 export function createTemporaryFile(content: string): Uri {


### PR DESCRIPTION
<!-- You could omit the sections that are not applicable to the changes. -->

### Features <!-- Describe the features that you have added -->

- Created a snippet to insert a regex test block into the `RegexMatch.rgx` file. The regex test block can be inserted with `ctrl+alt+g` keybinding as well.

### Tests <!-- Describe the tests that you have added or updated -->

- Created a test to check the insertion of the regex test block with the snippet command.

### Visual Changes <!-- Add screenshots, videos or GIFs to show the visual changes -->
![image](https://github.com/user-attachments/assets/a6d8776f-038e-45ef-a401-e817cbae1ce5)

---

Closes #124.

---

### Development Checklist

<!-- Check each of the following items before submitting the pull request. You can omit items that are not applicable to the changes. -->

- [x] I have tested the changes locally and unit and integration tests are passing.
- [x] I have added new tests and/or updated existing tests to cover the changes.
- [x] I have updated the documentations in both the [README.md](README.md) and [CHANGELOG.md](CHANGELOG.md) with the details of the changes.
