### PR TITLE
feat: allow to test many regex that came form the code (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v0.6.0]
 
 - Created a snippet to insert a regex test block into the regex test file.
+- Allowed to test many regex that came from the code in the regex test file by adding them below the existing ones.
 
 ## [v0.5.0] - 17/12/2024
 

--- a/src/services/regex-match/FileParser.ts
+++ b/src/services/regex-match/FileParser.ts
@@ -35,7 +35,6 @@ class FileParser {
             regexLineIndex,
             testLines,
             startTestIndex,
-            codeRegex,
           });
 
           regexTests.push(regexTest);
@@ -56,16 +55,19 @@ class FileParser {
       throw new RegexMatchFormatError(0);
     }
 
-    if (!codeRegex) {
-      this.insertCodeRegex(currentRegexTests, regexTests);
-    }
+    this.insertCodeRegex(currentRegexTests, regexTests, codeRegex);
 
     return regexTests;
   }
 
-  private static insertCodeRegex(currentRegexTests: RegexTest[], newRegexTests: RegexTest[]) {
+  private static insertCodeRegex(currentRegexTests: RegexTest[], newRegexTests: RegexTest[], newCodeRegex?: CodeRegex) {
+    const lastNewRegexTest = newRegexTests.at(-1);
+    if (lastNewRegexTest && newCodeRegex) {
+      lastNewRegexTest.setCodeRegex(newCodeRegex);
+    }
+
     const hasCodeRegex = currentRegexTests.some((regexTest) => regexTest.isCodeRegex());
-    if (currentRegexTests.length === 0 || !hasCodeRegex) {
+    if (currentRegexTests.length === 0 || (!hasCodeRegex && !newCodeRegex)) {
       return;
     }
 
@@ -97,6 +99,7 @@ class FileParser {
         if (regexTestWithSameMatchingRegexIndex !== -1) {
           newRegexTests[regexTestWithSameMatchingRegexIndex].setCodeRegex(currentRegexTest.getCodeRegex());
           newRegexTestsCopy.splice(regexTestWithSameMatchingRegexIndex, 1);
+          continue;
         }
 
         const regexTestWithSameTestStringIndex = newRegexTests.findIndex(

--- a/src/tests/integration/regex-match-window.test.ts
+++ b/src/tests/integration/regex-match-window.test.ts
@@ -47,7 +47,11 @@ describe('Regex Match Window', () => {
     const realEndPath = activeTextEditor!.document.fileName.replace(/[/\\]/g, '');
     const expectedEndPath = REGEX_TEST_FILE_PATH.replace(/\//g, '');
     assert.ok(realEndPath.endsWith(expectedEndPath));
-    assert.equal(activeTextEditor!.document.getText(), '/^\\d{2}\\w{3}/\n---\nType the test string here...\n---');
+
+    const expectedContent = `${DEFAULT_FILE_CONTENT}\n\n${codeRegex.pattern}\n---\nType the test string here...\n---`;
+    console.log('expectedContent', expectedContent);
+    console.log('activeTextEditor!.document.getText()', activeTextEditor!.document.getText());
+    assert.equal(activeTextEditor!.document.getText(), expectedContent);
   });
 
   it('should insert a regex test block using the snippet', async () => {

--- a/src/tests/unit/file-parser/file-parser.code-regex.test.ts
+++ b/src/tests/unit/file-parser/file-parser.code-regex.test.ts
@@ -59,6 +59,34 @@ describe('File Parser - Code Regex', () => {
     expect(regexTests[0].getCodeRegex()).toBe(oldCodeRegex);
   });
 
+  it('should maintain the code regex in the regex test when update the regex and the test string', () => {
+    const fileContent = '/[0-9]/gm\n---\ntest1\ntest2\n---';
+
+    const codeRegex: CodeRegex = {
+      pattern: '/[0-9]/gm',
+      documentUri: Uri.file('./file-parser.test.ts'),
+      range: new Range(0, 0, 0, 0),
+    };
+
+    let regexTests = FileParser.parseFileContent(fileContent, [], codeRegex);
+    expect(regexTests).not.toBeNull();
+    expect(regexTests).toHaveLength(1);
+
+    expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
+    expect(regexTests[0].isCodeRegex()).toBe(true);
+
+    const oldCodeRegex = regexTests[0].getCodeRegex();
+    const updatedFileContent = '/UPDATED-REGEX/g\n---\ntest3\ntest4\n---\n';
+
+    regexTests = FileParser.parseFileContent(updatedFileContent, regexTests);
+    expect(regexTests).not.toBeNull();
+    expect(regexTests).toHaveLength(1);
+
+    expect(regexTests[0].getMatchingRegex()).toStrictEqual(/UPDATED-REGEX/dg);
+    expect(regexTests[0].isCodeRegex()).toBe(true);
+    expect(regexTests[0].getCodeRegex()).toBe(oldCodeRegex);
+  });
+
   it('should maintain the code regex in the correct regex test when update the file content by adding a regex test below', () => {
     const fileContent = '/[0-9]/gm\n---\ntest1\ntest2\n---';
 
@@ -235,5 +263,97 @@ describe('File Parser - Code Regex', () => {
 
     expect(regexTests[1].getMatchingRegex()).toStrictEqual(/UPDATED-REGEX/dgm);
     expect(regexTests[1].isCodeRegex()).toBe(false);
+  });
+
+  it('should insert another regex test with code regex', () => {
+    const fileContent = '/[0-9]/gm\n---\ntest1\ntest2\n---';
+
+    const codeRegex: CodeRegex = {
+      pattern: '/[0-9]/gm',
+      documentUri: Uri.file('./file-parser.test.ts'),
+      range: new Range(0, 0, 0, 0),
+    };
+
+    let regexTests = FileParser.parseFileContent(fileContent, [], codeRegex);
+    expect(regexTests).not.toBeNull();
+    expect(regexTests).toHaveLength(1);
+
+    expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
+    expect(regexTests[0].isCodeRegex()).toBe(true);
+    expect(regexTests[0].getCodeRegExp()).toStrictEqual(/[0-9]/gm);
+
+    const updatedFileContent = '/[0-9]/gm\n---\ntest1\ntest2\n---\n/ANOTHER-REGEX/gm\n---\ntest3\ntest4\n---';
+
+    const newCodeRegex: CodeRegex = {
+      pattern: '/ANOTHER-REGEX/gm',
+      documentUri: Uri.file('./file-parser.test.ts'),
+      range: new Range(0, 0, 0, 0),
+    };
+
+    regexTests = FileParser.parseFileContent(updatedFileContent, regexTests, newCodeRegex);
+    expect(regexTests).not.toBeNull();
+    expect(regexTests).toHaveLength(2);
+
+    expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
+    expect(regexTests[0].isCodeRegex()).toBe(true);
+    expect(regexTests[0].getCodeRegExp()).toStrictEqual(/[0-9]/gm);
+
+    expect(regexTests[1].getMatchingRegex()).toStrictEqual(/ANOTHER-REGEX/dgm);
+    expect(regexTests[1].isCodeRegex()).toBe(true);
+    expect(regexTests[1].getCodeRegExp()).toStrictEqual(/ANOTHER-REGEX/gm);
+  });
+
+  it('should insert another regex test with code regex when already has a test without code regex', () => {
+    const fileContent = '/[0-9]/gm\n---\ntest1\ntest2\n---';
+
+    let regexTests = FileParser.parseFileContent(fileContent, []);
+    expect(regexTests).not.toBeNull();
+    expect(regexTests).toHaveLength(1);
+
+    expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
+    expect(regexTests[0].isCodeRegex()).toBeFalsy();
+
+    let updatedFileContent = '/[0-9]/gm\n---\ntest1\ntest2\n---\n/ANOTHER-REGEX/gm\n---\ntest3\ntest4\n---';
+
+    let newCodeRegex: CodeRegex = {
+      pattern: '/ANOTHER-REGEX/gm',
+      documentUri: Uri.file('./file-parser.test.ts'),
+      range: new Range(0, 0, 0, 0),
+    };
+
+    regexTests = FileParser.parseFileContent(updatedFileContent, regexTests, newCodeRegex);
+    expect(regexTests).not.toBeNull();
+    expect(regexTests).toHaveLength(2);
+
+    expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
+    expect(regexTests[0].isCodeRegex()).toBeFalsy();
+
+    expect(regexTests[1].getMatchingRegex()).toStrictEqual(/ANOTHER-REGEX/dgm);
+    expect(regexTests[1].isCodeRegex()).toBe(true);
+    expect(regexTests[1].getCodeRegExp()).toStrictEqual(/ANOTHER-REGEX/gm);
+
+    updatedFileContent =
+      '/[0-9]/gm\n---\ntest1\ntest2\n---\n/ANOTHER-REGEX/gm\n---\ntest3\ntest4\n---\n/ANOTHER-REGEX2/gm\n---\ntest5\ntest6\n---';
+
+    newCodeRegex = {
+      pattern: '/ANOTHER-REGEX2/gm',
+      documentUri: Uri.file('./file-parser.test.ts'),
+      range: new Range(0, 0, 0, 0),
+    };
+
+    regexTests = FileParser.parseFileContent(updatedFileContent, regexTests, newCodeRegex);
+    expect(regexTests).not.toBeNull();
+    expect(regexTests).toHaveLength(3);
+
+    expect(regexTests[0].getMatchingRegex()).toStrictEqual(/[0-9]/dgm);
+    expect(regexTests[0].isCodeRegex()).toBeFalsy();
+
+    expect(regexTests[1].getMatchingRegex()).toStrictEqual(/ANOTHER-REGEX/dgm);
+    expect(regexTests[1].isCodeRegex()).toBe(true);
+    expect(regexTests[1].getCodeRegExp()).toStrictEqual(/ANOTHER-REGEX/gm);
+
+    expect(regexTests[2].getMatchingRegex()).toStrictEqual(/ANOTHER-REGEX2/dgm);
+    expect(regexTests[2].isCodeRegex()).toBe(true);
+    expect(regexTests[2].getCodeRegExp()).toStrictEqual(/ANOTHER-REGEX2/gm);
   });
 });


### PR DESCRIPTION
<!-- You could omit the sections that are not applicable to the changes. -->

### Features <!-- Describe the features that you have added -->

- Insert regex test with code regex below the existing ones instead of replace all the file content with the regex test with code regex. This allows for many regex tests with regex patterns that came from the code. 

### Tests <!-- Describe the tests that you have added or updated -->

- Created tests to verify the behavior of the code regex maintenance when the file has many regex tests with code regex.
- Adjusted the integration test that verifies the insertion of regex test with code regex.

---

Closes #126.

---

### Development Checklist

<!-- Check each of the following items before submitting the pull request. You can omit items that are not applicable to the changes. -->

- [x] I have tested the changes locally and unit and integration tests are passing.
- [x] I have added new tests and/or updated existing tests to cover the changes.
- [x] I have updated the documentations in both the [README.md](README.md) and [CHANGELOG.md](CHANGELOG.md) with the details of the changes.
