### PR TITLE
fix: lost color highlight when open vscode (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Created a snippet to insert a regex test block into the regex test file.
 - Allowed to test many regex that came from the code in the regex test file by adding them below the existing ones.
+- Fixed loss of highlights when opening regex test file when opening VSCode.
 
 ## [v0.5.0] - 17/12/2024
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "onLanguage:javascriptreact",
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
+    "onLanguage:plaintext",
     "regex-match.openRegexMatchWindow"
   ],
   "contributes": {

--- a/src/tests/integration/regex-match-window.test.ts
+++ b/src/tests/integration/regex-match-window.test.ts
@@ -49,8 +49,6 @@ describe('Regex Match Window', () => {
     assert.ok(realEndPath.endsWith(expectedEndPath));
 
     const expectedContent = `${DEFAULT_FILE_CONTENT}\n\n${codeRegex.pattern}\n---\nType the test string here...\n---`;
-    console.log('expectedContent', expectedContent);
-    console.log('activeTextEditor!.document.getText()', activeTextEditor!.document.getText());
     assert.equal(activeTextEditor!.document.getText(), expectedContent);
   });
 


### PR DESCRIPTION
<!-- You could omit the sections that are not applicable to the changes. -->

### Fixes <!-- Describe the bug fixes that you have made -->

- Applied previous decorations when the test file lost color highlights when switching tabs.
- Allowed to enable extension on open plain text file to show color highlights when opening VS Code with regex test file open.

### Visual Changes <!-- Add screenshots, videos or GIFs to show the visual changes -->
https://github.com/user-attachments/assets/6ff4c12a-fda4-4731-b736-f82aa725d912

---

Closes #134.


---

### Development Checklist

<!-- Check each of the following items before submitting the pull request. You can omit items that are not applicable to the changes. -->

- [x] I have tested the changes locally and unit and integration tests are passing.
- [x] I have updated the documentations in both the [README.md](README.md) and [CHANGELOG.md](CHANGELOG.md) with the details of the changes.
