### PR TITLE
fix: detect regex with escaped slash (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v0.6.1]
 
 - Fixed the regex detector to detect regex in arrays.
+- Fixed regex detector to detect regex with slash in the middle of its text.
 
 ## [v0.6.0] - 09/03/2025
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The following settings are available to customize the extension:
 ## [v0.6.1]
 
 - Fixed the regex detector to detect regex in arrays.
+- Fixed regex detector to detect regex with slash in the middle of its text.
 
 ## [v0.6.0]
 

--- a/src/providers/code-lenses/utils.ts
+++ b/src/providers/code-lenses/utils.ts
@@ -1,5 +1,5 @@
 export const JAVASCRIPT_REGEX_DETECT =
-  /(?<!\/)(?<=[({=:>[,])\s*\/(?!\*)[^/\r\n][^\r\n]*?\/[gimuysvd]*\s*(?=[\]}),;\n]|\n|$)(?![^/]*\/\*|\*\/)/g;
+  /(?<!\/)(?<=[({=:>[,])\s*\/(?!\*)[^/\r\n][^\r\n]*?(?<!\\|\^)\/[gimuysvd]*\s*(?=[\]}),;\n]|\n|$)(?![^/]*\/\*|\*\/)/g;
 
 export const REGEX_DETECTORS_MAP: { [key in string]: RegExp | undefined } = {
   javascript: JAVASCRIPT_REGEX_DETECT,

--- a/src/tests/unit/code-regex-detect.test.ts
+++ b/src/tests/unit/code-regex-detect.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-useless-escape */
 import { expect, beforeEach, describe, it } from 'vitest';
 
 import { JAVASCRIPT_REGEX_DETECT, getRegexDetect } from '@/providers/code-lenses/utils';
@@ -141,10 +142,22 @@ describe('Code Regex Detect', () => {
       expect(matches[1][0].trim()).toEqual('/world/g');
     });
 
+    it('should detect regex with "/" in the middle of the regex', () => {
+      let code = 'const regex = /(ab\\/)ab/g;';
+
+      let matches = getAllMatches(regexDetect!, code);
+      expect(matches).toHaveLength(1);
+      expect(matches[0][0].trim()).toEqual('/(ab\\/)ab/g');
+
+      code = 'const regex = /[^/]/g';
+
+      matches = getAllMatches(regexDetect!, code);
+      expect(matches).toHaveLength(1);
+      expect(matches[0][0].trim()).toEqual('/[^/]/g');
+    });
+
     it.each(['g', 'i', 'm', 'u', 'y', 's', 'v'])(`should detect regex with flag '%s'`, (flag) => {
-      const code = `
-        const regex = /hello/${flag};
-      `;
+      const code = `const regex = /hello/${flag};`;
 
       const matches = getAllMatches(regexDetect!, code);
 


### PR DESCRIPTION
<!-- You could omit the sections that are not applicable to the changes. -->

### Fixes <!-- Describe the bug fixes that you have made -->

- Fixed regex detector to detect regex with slash in the middle of its text.

### Tests <!-- Describe the tests that you have added or updated -->

- Created test to correctly match regex with slash in the middle of the regex, considering `\/` and `^/`.

### Visual Changes <!-- Add screenshots, videos or GIFs to show the visual changes -->
![image](https://github.com/user-attachments/assets/58c1bc28-e9dc-46d9-b37b-78667e51f25c)
![image](https://github.com/user-attachments/assets/d5484acc-46af-49d5-ae63-e1c6f1908bc5)

---

Closes #145.

---

### Development Checklist

<!-- Check each of the following items before submitting the pull request. You can omit items that are not applicable to the changes. -->

- [x] I have tested the changes locally and unit and integration tests are passing.
- [x] I have added new tests and/or updated existing tests to cover the changes.
- [x] I have updated the documentations in both the [README.md](README.md) and [CHANGELOG.md](CHANGELOG.md) with the details of the changes.
