### PR TITLE
fix: resolve runaway test-block match consuming entire file (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v0.7.2]
+
+- Fixed the test-block end pattern that could never match, causing the rule to consume the entire file from the first regex line to EOF.
+
 ## [v0.7.1] - 21/02/2026
 
 - Fixed an issue when there are duplicate regex tests that came from code.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The following settings are available to customize the extension:
 
 ## 📝 Release Notes
 
+## [v0.7.2]
+
+- Fixed the test-block end pattern that could never match, causing the rule to consume the entire file from the first regex line to EOF.
+
 ## [v0.7.1]
 
 - Fixed an issue when there are duplicate regex tests that came from code.

--- a/src/tests/integration/regex-match-window.test.ts
+++ b/src/tests/integration/regex-match-window.test.ts
@@ -66,6 +66,7 @@ describe('Regex Match file', () => {
     activeTextEditor!.selection = new Selection(lastLine, lastLineLength, lastLine, lastLineLength);
 
     await commands.executeCommand('editor.action.insertLineAfter');
+    await wait(100);
     await commands.executeCommand('editor.action.insertSnippet', { name: 'Regex Test Block' });
     await wait(100);
 

--- a/src/tests/integration/regex-match-window.test.ts
+++ b/src/tests/integration/regex-match-window.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { after, beforeEach, describe, it } from 'mocha';
-import { Range, Selection, ViewColumn, commands, window, workspace } from 'vscode';
+import { Position, Range, Selection, ViewColumn, commands, window, workspace } from 'vscode';
 
 import { DEFAULT_FILE_CONTENT } from '@/controllers/regex-test/FileCreator';
 import { REGEX_TEST_FILE_PATH } from '@/controllers/regex-test/RegexTestController';
@@ -60,13 +60,15 @@ describe('Regex Match file', () => {
 
     assert.notEqual(activeTextEditor, undefined);
 
-    const lastLine = activeTextEditor!.document.lineCount - 1;
-    const lastLineLength = activeTextEditor!.document.lineAt(lastLine).text.length;
+    await activeTextEditor!.edit((editBuilder) => {
+      const lastLine = activeTextEditor!.document.lineCount - 1;
+      const lastLineLength = activeTextEditor!.document.lineAt(lastLine).text.length;
+      editBuilder.insert(new Position(lastLine, lastLineLength), '\n');
+    });
 
-    activeTextEditor!.selection = new Selection(lastLine, lastLineLength, lastLine, lastLineLength);
+    const newLastLine = activeTextEditor!.document.lineCount - 1;
+    activeTextEditor!.selection = new Selection(newLastLine, 0, newLastLine, 0);
 
-    await commands.executeCommand('editor.action.insertLineAfter');
-    await wait(100);
     await commands.executeCommand('editor.action.insertSnippet', { name: 'Regex Test Block' });
     await wait(100);
 

--- a/src/tests/integration/regex-match-window.test.ts
+++ b/src/tests/integration/regex-match-window.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { after, beforeEach, describe, it } from 'mocha';
-import { Position, Range, Selection, ViewColumn, commands, window, workspace } from 'vscode';
+import { Position, Range, SnippetString, ViewColumn, commands, window, workspace } from 'vscode';
 
 import { DEFAULT_FILE_CONTENT } from '@/controllers/regex-test/FileCreator';
 import { REGEX_TEST_FILE_PATH } from '@/controllers/regex-test/RegexTestController';
@@ -67,16 +67,15 @@ describe('Regex Match file', () => {
     });
 
     const newLastLine = activeTextEditor!.document.lineCount - 1;
-    activeTextEditor!.selection = new Selection(newLastLine, 0, newLastLine, 0);
+    const snippetBody = snippets['Regex Test Block'].body.join('\n');
 
-    await commands.executeCommand('editor.action.insertSnippet', { name: 'Regex Test Block' });
-    await wait(100);
+    await activeTextEditor!.insertSnippet(new SnippetString(snippetBody), new Position(newLastLine, 0));
 
-    const snippetBody = snippets['Regex Test Block'].body.join('\n').replace(/\${\d:|}/g, '');
+    const expectedSnippetBody = snippetBody.replace(/\${\d:|}/g, '');
 
     const textEditor = activeTextEditor!.document.getText().replace(/\r\n/g, '\n');
     const expectedDefault = DEFAULT_FILE_CONTENT.replace(/\r\n/g, '\n');
-    const expectedSnippet = snippetBody.replace(/\r\n/g, '\n');
+    const expectedSnippet = expectedSnippetBody.replace(/\r\n/g, '\n');
 
     assert.ok(textEditor.startsWith(expectedDefault));
 

--- a/src/tests/unit/grammar/regex-match-grammar.test.ts
+++ b/src/tests/unit/grammar/regex-match-grammar.test.ts
@@ -61,7 +61,13 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[2], {
       startIndex: 2,
       endIndex: 5,
-      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'constant.other.character-class.set.regexp'],
+      scopes: [
+        'source.rgx',
+        'meta.regex-line.rgx',
+        'string.regexp.rgx',
+        'constant.other.character-class.set.regexp',
+        'constant.other.character-class.range.regexp',
+      ],
     });
     expectToken(tokens[3], {
       startIndex: 5,
@@ -576,7 +582,13 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[0].tokens[2], {
       startIndex: 2,
       endIndex: 5,
-      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'constant.other.character-class.set.regexp'],
+      scopes: [
+        'source.rgx',
+        'meta.regex-line.rgx',
+        'string.regexp.rgx',
+        'constant.other.character-class.set.regexp',
+        'constant.other.character-class.range.regexp',
+      ],
     });
     expectToken(allTokens[0].tokens[3], {
       startIndex: 5,
@@ -689,7 +701,13 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[0].tokens[2], {
       startIndex: 2,
       endIndex: 5,
-      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'constant.other.character-class.set.regexp'],
+      scopes: [
+        'source.rgx',
+        'meta.regex-line.rgx',
+        'string.regexp.rgx',
+        'constant.other.character-class.set.regexp',
+        'constant.other.character-class.range.regexp',
+      ],
     });
     expectToken(allTokens[0].tokens[3], {
       startIndex: 5,
@@ -789,7 +807,13 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[7].tokens[2], {
       startIndex: 2,
       endIndex: 5,
-      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'constant.other.character-class.set.regexp'],
+      scopes: [
+        'source.rgx',
+        'meta.regex-line.rgx',
+        'string.regexp.rgx',
+        'constant.other.character-class.set.regexp',
+        'constant.other.character-class.range.regexp',
+      ],
     });
     expectToken(allTokens[7].tokens[3], {
       startIndex: 5,
@@ -836,6 +860,16 @@ describe('Regex Match Grammar', () => {
       endIndex: 4,
       scopes: ['source.rgx', 'meta.test-block.rgx', 'punctuation.separator.test.end.rgx'],
     });
+  });
+
+  it('should tokenize character class ranges', () => {
+    const line = '/[a-zA-Z0-9]/';
+    const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);
+
+    expectTokenWithScopes(tokens, [
+      'constant.other.character-class.set.regexp',
+      'constant.other.character-class.range.regexp',
+    ]);
   });
 
   it('should tokenize negated character class', () => {

--- a/src/tests/unit/grammar/regex-match-grammar.test.ts
+++ b/src/tests/unit/grammar/regex-match-grammar.test.ts
@@ -28,6 +28,16 @@ describe('Regex Match Grammar', () => {
     expect(token.scopes).toEqual(scopes);
   }
 
+  function expectTokenWithScopes(tokens: vscodeTextmate.IToken[], scopes: string[]) {
+    const hasScopes = tokens.some((token) => scopes.every((scope) => token.scopes.includes(scope)));
+    expect(hasScopes).toBe(true);
+  }
+
+  function expectNotTokenWithScopes(tokens: vscodeTextmate.IToken[], scopes: string[]) {
+    const hasScopes = tokens.some((token) => scopes.every((scope) => token.scopes.includes(scope)));
+    expect(hasScopes).toBe(false);
+  }
+
   it('should tokenize simple regex', () => {
     const line = '/[a-z]+/gi';
     const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);
@@ -35,14 +45,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 2,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -51,20 +61,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[2], {
       startIndex: 2,
       endIndex: 5,
-      scopes: [
-        'source.rgx',
-        'meta.test-block.rgx',
-        'string.regexp.rgx',
-        'constant.other.character-class.set.regexp',
-        'constant.other.character-class.range.regexp',
-      ],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'constant.other.character-class.set.regexp'],
     });
     expectToken(tokens[3], {
       startIndex: 5,
       endIndex: 6,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -73,19 +77,19 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[4], {
       startIndex: 6,
       endIndex: 7,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
     });
     expectToken(tokens[5], {
       startIndex: 7,
       endIndex: 8,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
     expectToken(tokens[6], {
       startIndex: 8,
       endIndex: 10,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'punctuation.definition.string.end.rgx',
         'keyword.other.rgx',
@@ -100,22 +104,22 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 2,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx'],
     });
     expectToken(tokens[2], {
       startIndex: 2,
       endIndex: 8,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
     });
     expectToken(tokens[3], {
       startIndex: 8,
       endIndex: 9,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
   });
 
@@ -126,14 +130,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 4,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.regexp',
         'punctuation.definition.group.regexp',
@@ -144,7 +148,7 @@ describe('Regex Match Grammar', () => {
       endIndex: 8,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.regexp',
         'punctuation.definition.group.regexp',
@@ -156,7 +160,7 @@ describe('Regex Match Grammar', () => {
       endIndex: 9,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.regexp',
         'punctuation.definition.group.regexp',
@@ -165,14 +169,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[4], {
       startIndex: 9,
       endIndex: 12,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'meta.group.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'meta.group.regexp'],
     });
     expectToken(tokens[5], {
       startIndex: 12,
       endIndex: 13,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.regexp',
         'punctuation.definition.group.regexp',
@@ -181,7 +185,7 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[6], {
       startIndex: 13,
       endIndex: 14,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
   });
 
@@ -192,14 +196,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 2,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.regexp',
         'punctuation.definition.group.regexp',
@@ -210,7 +214,7 @@ describe('Regex Match Grammar', () => {
       endIndex: 4,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.regexp',
         'punctuation.definition.group.regexp',
@@ -220,14 +224,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[3], {
       startIndex: 4,
       endIndex: 7,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'meta.group.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'meta.group.regexp'],
     });
     expectToken(tokens[4], {
       startIndex: 7,
       endIndex: 8,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.regexp',
         'punctuation.definition.group.regexp',
@@ -236,7 +240,7 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[5], {
       startIndex: 8,
       endIndex: 9,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
   });
 
@@ -247,14 +251,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 2,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -265,7 +269,7 @@ describe('Regex Match Grammar', () => {
       endIndex: 4,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'constant.other.character-class.regexp',
@@ -276,7 +280,7 @@ describe('Regex Match Grammar', () => {
       endIndex: 6,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'constant.other.character-class.regexp',
@@ -287,7 +291,7 @@ describe('Regex Match Grammar', () => {
       endIndex: 7,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -296,7 +300,7 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[5], {
       startIndex: 7,
       endIndex: 8,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
   });
 
@@ -307,27 +311,27 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 2,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.control.anchor.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.control.anchor.regexp'],
     });
     expectToken(tokens[2], {
       startIndex: 2,
       endIndex: 5,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx'],
     });
     expectToken(tokens[3], {
       startIndex: 5,
       endIndex: 6,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.control.anchor.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.control.anchor.regexp'],
     });
     expectToken(tokens[4], {
       startIndex: 6,
       endIndex: 7,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
 
     expect(tokens.some((t) => t.scopes.includes('keyword.control.anchor.regexp'))).toBe(true);
@@ -340,27 +344,27 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 2,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx'],
     });
     expectToken(tokens[2], {
       startIndex: 2,
       endIndex: 3,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.operator.or.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.operator.or.regexp'],
     });
     expectToken(tokens[3], {
       startIndex: 3,
       endIndex: 4,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx'],
     });
     expectToken(tokens[4], {
       startIndex: 4,
       endIndex: 5,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
   });
 
@@ -371,14 +375,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 2,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.regexp',
         'punctuation.definition.group.regexp',
@@ -387,14 +391,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[2], {
       startIndex: 2,
       endIndex: 3,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'meta.group.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'meta.group.regexp'],
     });
     expectToken(tokens[3], {
       startIndex: 3,
       endIndex: 4,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.regexp',
         'punctuation.definition.group.regexp',
@@ -403,12 +407,12 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[4], {
       startIndex: 4,
       endIndex: 6,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.other.back-reference.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.other.back-reference.regexp'],
     });
     expectToken(tokens[5], {
       startIndex: 6,
       endIndex: 7,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
   });
 
@@ -419,19 +423,19 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 2,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx'],
     });
     expectToken(tokens[2], {
       startIndex: 2,
       endIndex: 3,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.assertion.regexp',
         'punctuation.definition.group.regexp',
@@ -442,7 +446,7 @@ describe('Regex Match Grammar', () => {
       endIndex: 5,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.assertion.regexp',
         'punctuation.definition.group.assertion.regexp',
@@ -452,14 +456,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[4], {
       startIndex: 5,
       endIndex: 6,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'meta.group.assertion.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'meta.group.assertion.regexp'],
     });
     expectToken(tokens[5], {
       startIndex: 6,
       endIndex: 7,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.assertion.regexp',
         'punctuation.definition.group.regexp',
@@ -470,7 +474,7 @@ describe('Regex Match Grammar', () => {
       endIndex: 8,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.assertion.regexp',
         'punctuation.definition.group.regexp',
@@ -481,7 +485,7 @@ describe('Regex Match Grammar', () => {
       endIndex: 11,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.assertion.regexp',
         'punctuation.definition.group.assertion.regexp',
@@ -491,14 +495,14 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[8], {
       startIndex: 11,
       endIndex: 12,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'meta.group.assertion.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'meta.group.assertion.regexp'],
     });
     expectToken(tokens[9], {
       startIndex: 12,
       endIndex: 13,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'meta.group.assertion.regexp',
         'punctuation.definition.group.regexp',
@@ -507,7 +511,7 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[10], {
       startIndex: 13,
       endIndex: 14,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
   });
 
@@ -518,24 +522,24 @@ describe('Regex Match Grammar', () => {
     expectToken(tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(tokens[1], {
       startIndex: 1,
       endIndex: 4,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx'],
     });
     expectToken(tokens[2], {
       startIndex: 4,
       endIndex: 5,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
     expectToken(tokens[3], {
       startIndex: 5,
       endIndex: 7,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'punctuation.definition.string.end.rgx',
         'keyword.other.rgx',
@@ -556,14 +560,14 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[0].tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(allTokens[0].tokens[1], {
       startIndex: 1,
       endIndex: 2,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -572,20 +576,14 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[0].tokens[2], {
       startIndex: 2,
       endIndex: 5,
-      scopes: [
-        'source.rgx',
-        'meta.test-block.rgx',
-        'string.regexp.rgx',
-        'constant.other.character-class.set.regexp',
-        'constant.other.character-class.range.regexp',
-      ],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'constant.other.character-class.set.regexp'],
     });
     expectToken(allTokens[0].tokens[3], {
       startIndex: 5,
       endIndex: 6,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -594,29 +592,29 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[0].tokens[4], {
       startIndex: 6,
       endIndex: 7,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
     });
     expectToken(allTokens[0].tokens[5], {
       startIndex: 7,
       endIndex: 8,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx'],
     });
     expectToken(allTokens[0].tokens[6], {
       startIndex: 8,
       endIndex: 9,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
     });
     expectToken(allTokens[0].tokens[7], {
       startIndex: 9,
       endIndex: 10,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
     expectToken(allTokens[0].tokens[8], {
       startIndex: 10,
       endIndex: 12,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'punctuation.definition.string.end.rgx',
         'keyword.other.rgx',
@@ -625,32 +623,27 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[1].tokens[0], {
       startIndex: 0,
       endIndex: 4,
-      scopes: [
-        'source.rgx',
-        'meta.test-block.rgx',
-        'meta.test-declaration.rgx',
-        'punctuation.separator.test.begin.rgx',
-      ],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'punctuation.separator.test.begin.rgx'],
     });
     expectToken(allTokens[2].tokens[0], {
       startIndex: 0,
       endIndex: 6,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'text.test-content.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
     });
     expectToken(allTokens[3].tokens[0], {
       startIndex: 0,
       endIndex: 7,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'text.test-content.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
     });
     expectToken(allTokens[4].tokens[0], {
       startIndex: 0,
       endIndex: 6,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'text.test-content.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
     });
     expectToken(allTokens[5].tokens[0], {
       startIndex: 0,
       endIndex: 4,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'punctuation.separator.test.end.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'punctuation.separator.test.end.rgx'],
     });
   });
 
@@ -680,14 +673,14 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[0].tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(allTokens[0].tokens[1], {
       startIndex: 1,
       endIndex: 2,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -696,20 +689,14 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[0].tokens[2], {
       startIndex: 2,
       endIndex: 5,
-      scopes: [
-        'source.rgx',
-        'meta.test-block.rgx',
-        'string.regexp.rgx',
-        'constant.other.character-class.set.regexp',
-        'constant.other.character-class.range.regexp',
-      ],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'constant.other.character-class.set.regexp'],
     });
     expectToken(allTokens[0].tokens[3], {
       startIndex: 5,
       endIndex: 6,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -718,29 +705,29 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[0].tokens[4], {
       startIndex: 6,
       endIndex: 7,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
     });
     expectToken(allTokens[0].tokens[5], {
       startIndex: 7,
       endIndex: 8,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx'],
     });
     expectToken(allTokens[0].tokens[6], {
       startIndex: 8,
       endIndex: 9,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
     });
     expectToken(allTokens[0].tokens[7], {
       startIndex: 9,
       endIndex: 10,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
     expectToken(allTokens[0].tokens[8], {
       startIndex: 10,
       endIndex: 12,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'punctuation.definition.string.end.rgx',
         'keyword.other.rgx',
@@ -750,55 +737,50 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[1].tokens[0], {
       startIndex: 0,
       endIndex: 4,
-      scopes: [
-        'source.rgx',
-        'meta.test-block.rgx',
-        'meta.test-declaration.rgx',
-        'punctuation.separator.test.begin.rgx',
-      ],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'punctuation.separator.test.begin.rgx'],
     });
 
     expectToken(allTokens[2].tokens[0], {
       startIndex: 0,
       endIndex: 6,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'text.test-content.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
     });
 
     expectToken(allTokens[3].tokens[0], {
       startIndex: 0,
       endIndex: 7,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'text.test-content.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
     });
 
     expectToken(allTokens[4].tokens[0], {
       startIndex: 0,
       endIndex: 6,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'text.test-content.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
     });
 
     expectToken(allTokens[5].tokens[0], {
       startIndex: 0,
       endIndex: 4,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'punctuation.separator.test.end.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'punctuation.separator.test.end.rgx'],
     });
 
     expectToken(allTokens[6].tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx'],
+      scopes: ['source.rgx'],
     });
 
     expectToken(allTokens[7].tokens[0], {
       startIndex: 0,
       endIndex: 1,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
     });
     expectToken(allTokens[7].tokens[1], {
       startIndex: 1,
       endIndex: 2,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -807,20 +789,14 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[7].tokens[2], {
       startIndex: 2,
       endIndex: 5,
-      scopes: [
-        'source.rgx',
-        'meta.test-block.rgx',
-        'string.regexp.rgx',
-        'constant.other.character-class.set.regexp',
-        'constant.other.character-class.range.regexp',
-      ],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'constant.other.character-class.set.regexp'],
     });
     expectToken(allTokens[7].tokens[3], {
       startIndex: 5,
       endIndex: 6,
       scopes: [
         'source.rgx',
-        'meta.test-block.rgx',
+        'meta.regex-line.rgx',
         'string.regexp.rgx',
         'constant.other.character-class.set.regexp',
         'punctuation.definition.character-class.regexp',
@@ -829,41 +805,168 @@ describe('Regex Match Grammar', () => {
     expectToken(allTokens[7].tokens[4], {
       startIndex: 6,
       endIndex: 7,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'keyword.operator.quantifier.regexp'],
     });
     expectToken(allTokens[7].tokens[5], {
       startIndex: 7,
       endIndex: 8,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
     });
 
     expectToken(allTokens[8].tokens[0], {
       startIndex: 0,
       endIndex: 4,
-      scopes: [
-        'source.rgx',
-        'meta.test-block.rgx',
-        'meta.test-declaration.rgx',
-        'punctuation.separator.test.begin.rgx',
-      ],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'punctuation.separator.test.begin.rgx'],
     });
 
     expectToken(allTokens[9].tokens[0], {
       startIndex: 0,
       endIndex: 3,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'text.test-content.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
     });
 
     expectToken(allTokens[10].tokens[0], {
       startIndex: 0,
       endIndex: 3,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'text.test-content.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
     });
 
     expectToken(allTokens[11].tokens[0], {
       startIndex: 0,
       endIndex: 4,
-      scopes: ['source.rgx', 'meta.test-block.rgx', 'meta.test-declaration.rgx', 'punctuation.separator.test.end.rgx'],
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'punctuation.separator.test.end.rgx'],
     });
+  });
+
+  it('should tokenize negated character class', () => {
+    const line = '/[^a]/';
+    const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);
+
+    expectToken(tokens[0], {
+      startIndex: 0,
+      endIndex: 1,
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.begin.rgx'],
+    });
+    expectToken(tokens[1], {
+      startIndex: 1,
+      endIndex: 2,
+      scopes: [
+        'source.rgx',
+        'meta.regex-line.rgx',
+        'string.regexp.rgx',
+        'constant.other.character-class.set.regexp',
+        'punctuation.definition.character-class.regexp',
+      ],
+    });
+    expectToken(tokens[2], {
+      startIndex: 2,
+      endIndex: 3,
+      scopes: [
+        'source.rgx',
+        'meta.regex-line.rgx',
+        'string.regexp.rgx',
+        'constant.other.character-class.set.regexp',
+        'keyword.operator.negation.regexp',
+      ],
+    });
+    expectToken(tokens[3], {
+      startIndex: 3,
+      endIndex: 4,
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'constant.other.character-class.set.regexp'],
+    });
+    expectToken(tokens[4], {
+      startIndex: 4,
+      endIndex: 5,
+      scopes: [
+        'source.rgx',
+        'meta.regex-line.rgx',
+        'string.regexp.rgx',
+        'constant.other.character-class.set.regexp',
+        'punctuation.definition.character-class.regexp',
+      ],
+    });
+    expectToken(tokens[5], {
+      startIndex: 5,
+      endIndex: 6,
+      scopes: ['source.rgx', 'meta.regex-line.rgx', 'string.regexp.rgx', 'punctuation.definition.string.end.rgx'],
+    });
+  });
+
+  it('should tokenize negative lookahead and lookbehind', () => {
+    const line = '/a(?!b)(?<!c)/';
+    const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);
+
+    expectTokenWithScopes(tokens, ['meta.group.assertion.regexp', 'meta.assertion.negative-look-ahead.regexp']);
+    expectTokenWithScopes(tokens, ['meta.group.assertion.regexp', 'meta.assertion.negative-look-behind.regexp']);
+  });
+
+  it('should tokenize named backreference', () => {
+    const line = '/(a)\\k<name>/';
+    const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);
+
+    expectTokenWithScopes(tokens, ['keyword.other.back-reference.regexp']);
+    expectTokenWithScopes(tokens, ['variable.other.regexp']);
+  });
+
+  it('should tokenize numeric and control escapes', () => {
+    const line = '/\\x4F\\u00A9\\cA/';
+    const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);
+
+    expectTokenWithScopes(tokens, ['constant.character.numeric.regexp']);
+    expectTokenWithScopes(tokens, ['constant.character.control.regexp']);
+  });
+
+  it('should treat regex-like text inside test block as text', () => {
+    const lines = ['---', '/abc/', '---'];
+    let ruleStack = vscodeTextmate.INITIAL;
+    const allTokens: { line: string; tokens: vscodeTextmate.IToken[] }[] = [];
+    for (const line of lines) {
+      const res = grammar.tokenizeLine(line, ruleStack);
+      allTokens.push({ line, tokens: res.tokens });
+      ruleStack = res.ruleStack;
+    }
+
+    expectToken(allTokens[1].tokens[0], {
+      startIndex: 0,
+      endIndex: 5,
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
+    });
+  });
+
+  it('should not tokenize plain text as regex line', () => {
+    const line = 'abc/def';
+    const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);
+
+    expectToken(tokens[0], {
+      startIndex: 0,
+      endIndex: 8,
+      scopes: ['source.rgx'],
+    });
+    expectNotTokenWithScopes(tokens, ['meta.regex-line.rgx']);
+  });
+
+  it('should not treat indented regex as regex line', () => {
+    const line = '  /abc/';
+    const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);
+
+    expectToken(tokens[0], {
+      startIndex: 0,
+      endIndex: 8,
+      scopes: ['source.rgx'],
+    });
+    expectNotTokenWithScopes(tokens, ['meta.regex-line.rgx']);
+  });
+
+  it('should not start test block for malformed delimiter', () => {
+    const line = '---x';
+    const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);
+
+    expectToken(tokens[0], {
+      startIndex: 0,
+      endIndex: 5,
+      scopes: ['source.rgx'],
+    });
+    expectNotTokenWithScopes(tokens, ['meta.test-block.rgx']);
+    expectNotTokenWithScopes(tokens, ['punctuation.separator.test.begin.rgx']);
   });
 });

--- a/src/tests/unit/grammar/regex-match-grammar.test.ts
+++ b/src/tests/unit/grammar/regex-match-grammar.test.ts
@@ -957,6 +957,49 @@ describe('Regex Match Grammar', () => {
     expectNotTokenWithScopes(tokens, ['meta.regex-line.rgx']);
   });
 
+  it('should not consume content after a closed test block', () => {
+    const lines = ['/abc/', '---', 'foo', '---', 'trailing line', '/xyz/'];
+    let ruleStack = vscodeTextmate.INITIAL;
+    const allTokens: { line: string; tokens: vscodeTextmate.IToken[] }[] = [];
+    for (const line of lines) {
+      const res = grammar.tokenizeLine(line, ruleStack);
+      allTokens.push({ line, tokens: res.tokens });
+      ruleStack = res.ruleStack;
+    }
+
+    expectNotTokenWithScopes(allTokens[4].tokens, ['meta.test-block.rgx']);
+    expectToken(allTokens[4].tokens[0], {
+      startIndex: 0,
+      endIndex: 14,
+      scopes: ['source.rgx'],
+    });
+
+    expectTokenWithScopes(allTokens[5].tokens, ['meta.regex-line.rgx']);
+    expectNotTokenWithScopes(allTokens[5].tokens, ['meta.test-block.rgx']);
+  });
+
+  it('should keep an unclosed test block open until EOF', () => {
+    const lines = ['/abc/', '---', 'foo', 'bar'];
+    let ruleStack = vscodeTextmate.INITIAL;
+    const allTokens: { line: string; tokens: vscodeTextmate.IToken[] }[] = [];
+    for (const line of lines) {
+      const res = grammar.tokenizeLine(line, ruleStack);
+      allTokens.push({ line, tokens: res.tokens });
+      ruleStack = res.ruleStack;
+    }
+
+    expectToken(allTokens[2].tokens[0], {
+      startIndex: 0,
+      endIndex: 3,
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
+    });
+    expectToken(allTokens[3].tokens[0], {
+      startIndex: 0,
+      endIndex: 3,
+      scopes: ['source.rgx', 'meta.test-block.rgx', 'text.test-content.rgx'],
+    });
+  });
+
   it('should not start test block for malformed delimiter', () => {
     const line = '---x';
     const { tokens } = grammar.tokenizeLine(line, vscodeTextmate.INITIAL);

--- a/syntaxes/regex-match.tmLanguage.json
+++ b/syntaxes/regex-match.tmLanguage.json
@@ -12,7 +12,7 @@
   "repository": {
     "regex-line": {
       "name": "meta.regex-line.rgx",
-      "match": "^/.*$",
+      "match": "^/.*/[dgimsuvy]*\\s*$",
       "captures": {
         "0": {
           "patterns": [{ "include": "#regexp" }]
@@ -33,7 +33,7 @@
       "patterns": [
         {
           "name": "text.test-content.rgx",
-          "match": "^(?!---\\s*$).*$"
+          "match": "^.*$"
         }
       ]
     },

--- a/syntaxes/regex-match.tmLanguage.json
+++ b/syntaxes/regex-match.tmLanguage.json
@@ -3,59 +3,59 @@
   "scopeName": "source.rgx",
   "patterns": [
     {
-      "name": "meta.test-block.rgx",
-      "begin": "^(?=/)",
-      "end": "^---\\s*$\\n^---\\s*$",
-      "patterns": [
-        { "include": "#regexp" },
-        {
-          "name": "meta.test-declaration.rgx",
-          "begin": "^---\\s*$",
-          "end": "^---\\s*$",
-          "beginCaptures": {
-            "0": { "name": "punctuation.separator.test.begin.rgx" }
-          },
-          "endCaptures": {
-            "0": { "name": "punctuation.separator.test.end.rgx" }
-          },
-          "patterns": [
-            {
-              "name": "text.test-content.rgx",
-              "match": "^.*$"
-            }
-          ]
-        }
-      ]
+      "include": "#regex-line"
+    },
+    {
+      "include": "#test-block"
     }
   ],
   "repository": {
+    "regex-line": {
+      "name": "meta.regex-line.rgx",
+      "match": "^/.*$",
+      "captures": {
+        "0": {
+          "patterns": [{ "include": "#regexp" }]
+        }
+      }
+    },
+
+    "test-block": {
+      "name": "meta.test-block.rgx",
+      "begin": "^---\\s*$",
+      "end": "^---\\s*$",
+      "beginCaptures": {
+        "0": { "name": "punctuation.separator.test.begin.rgx" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.separator.test.end.rgx" }
+      },
+      "patterns": [
+        {
+          "name": "text.test-content.rgx",
+          "match": "^(?!---\\s*$).*$"
+        }
+      ]
+    },
+
     "regexp": {
       "patterns": [
         {
           "name": "string.regexp.rgx",
           "begin": "(/)",
           "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.begin.rgx"
-            }
+            "0": { "name": "punctuation.definition.string.begin.rgx" }
           },
           "end": "/([dgimsuvy]*)",
           "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.end.rgx"
-            },
-            "1": {
-              "name": "keyword.other.rgx"
-            }
+            "0": { "name": "punctuation.definition.string.end.rgx" },
+            "1": { "name": "keyword.other.rgx" }
           },
-          "patterns": [
-            {
-              "include": "#regex-body"
-            }
-          ]
+          "patterns": [{ "include": "#regex-body" }]
         }
       ]
     },
+
     "regex-body": {
       "patterns": [
         {
@@ -65,12 +65,8 @@
         {
           "match": "\\\\[1-9]\\d*|\\\\k<([a-zA-Z_$][\\w$]*)>",
           "captures": {
-            "0": {
-              "name": "keyword.other.back-reference.regexp"
-            },
-            "1": {
-              "name": "variable.other.regexp"
-            }
+            "0": { "name": "keyword.other.back-reference.regexp" },
+            "1": { "name": "variable.other.regexp" }
           }
         },
         {
@@ -94,82 +90,41 @@
           },
           "end": "(\\))",
           "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.group.regexp"
-            }
+            "1": { "name": "punctuation.definition.group.regexp" }
           },
-          "patterns": [
-            {
-              "include": "#regex-body"
-            }
-          ]
+          "patterns": [{ "include": "#regex-body" }]
         },
         {
           "name": "meta.group.regexp",
           "begin": "\\((?:(\\?:)|(?:\\?<([a-zA-Z_$][\\w$]*)>))?",
           "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.group.regexp"
-            },
-            "1": {
-              "name": "punctuation.definition.group.no-capture.regexp"
-            },
-            "2": {
-              "name": "variable.other.regexp"
-            }
+            "0": { "name": "punctuation.definition.group.regexp" },
+            "1": { "name": "punctuation.definition.group.no-capture.regexp" },
+            "2": { "name": "variable.other.regexp" }
           },
           "end": "\\)",
           "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.group.regexp"
-            }
+            "0": { "name": "punctuation.definition.group.regexp" }
           },
-          "patterns": [
-            {
-              "include": "#regex-body"
-            }
-          ]
+          "patterns": [{ "include": "#regex-body" }]
         },
         {
           "name": "constant.other.character-class.set.regexp",
           "begin": "(\\[)(\\^)?",
           "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.character-class.regexp"
-            },
-            "2": {
-              "name": "keyword.operator.negation.regexp"
-            }
+            "1": { "name": "punctuation.definition.character-class.regexp" },
+            "2": { "name": "keyword.operator.negation.regexp" }
           },
           "end": "(\\])",
           "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.character-class.regexp"
-            }
+            "1": { "name": "punctuation.definition.character-class.regexp" }
           },
-          "patterns": [
-            {
-              "name": "constant.other.character-class.range.regexp",
-              "match": "(?:.|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))",
-              "captures": {
-                "1": { "name": "constant.character.numeric.regexp" },
-                "2": { "name": "constant.character.control.regexp" },
-                "3": { "name": "constant.character.escape.backslash.regexp" },
-                "4": { "name": "constant.character.numeric.regexp" },
-                "5": { "name": "constant.character.control.regexp" },
-                "6": { "name": "constant.character.escape.backslash.regexp" }
-              }
-            },
-            {
-              "include": "#regex-character-class"
-            }
-          ]
+          "patterns": [{ "include": "#regex-character-class" }]
         },
-        {
-          "include": "#regex-character-class"
-        }
+        { "include": "#regex-character-class" }
       ]
     },
+
     "regex-character-class": {
       "patterns": [
         {

--- a/syntaxes/regex-match.tmLanguage.json
+++ b/syntaxes/regex-match.tmLanguage.json
@@ -119,7 +119,13 @@
           "endCaptures": {
             "1": { "name": "punctuation.definition.character-class.regexp" }
           },
-          "patterns": [{ "include": "#regex-character-class" }]
+          "patterns": [
+            {
+              "name": "constant.other.character-class.range.regexp",
+              "match": "(?:\\\\.|[^\\\\\\]\\-])-(?:\\\\.|[^\\\\\\]\\-])"
+            },
+            { "include": "#regex-character-class" }
+          ]
         },
         { "include": "#regex-character-class" }
       ]


### PR DESCRIPTION
<!-- You could omit the sections that are not applicable to the changes. -->

### Fixes <!-- Describe the bug fixes that you have made -->

- Fix the test-block end pattern that could never match, causing the rule to consume the entire file from the first regex line to EOF.

### Tests <!-- Describe the tests that you have added or updated -->

- Add regression tests for the runaway test-block match and for the unclosed test-block behavior.

---

Closes #171.

---

### Development Checklist

<!-- Check each of the following items before submitting the pull request. You can omit items that are not applicable to the changes. -->

- [x] I have tested the changes locally and unit and integration tests are passing.
- [x] I have added new tests and/or updated existing tests to cover the changes.
- [x] I have updated the documentations in both the [README.md](README.md) and [CHANGELOG.md](CHANGELOG.md) with the details of the changes.
