### PR TITLE
feat: scope regex errors to their own block (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v0.8.0]
+
+- Scoped invalid regex errors to their own test block, keeping the other blocks highlighted instead of dropping every highlight in the file.
+
 ## [v0.7.2] - 10/06/2026
 
 - Fixed the test-block end pattern that could never match, causing the rule to consume the entire file from the first regex line to EOF.

--- a/src/controllers/regex-test/FileParser.ts
+++ b/src/controllers/regex-test/FileParser.ts
@@ -92,9 +92,10 @@ class FileParser {
           continue;
         }
 
-        const regexTestWithSameMatchingRegexIndex = newRegexTests.findIndex(
-          (regexTest) => regexTest.getMatchingRegexSource() === currentRegexTest.getMatchingRegexSource(),
-        );
+        const currentMatchingRegexSource = currentRegexTest.getMatchingRegexSource();
+        const regexTestWithSameMatchingRegexIndex = currentMatchingRegexSource
+          ? newRegexTests.findIndex((regexTest) => regexTest.getMatchingRegexSource() === currentMatchingRegexSource)
+          : -1;
 
         if (regexTestWithSameMatchingRegexIndex !== -1) {
           newRegexTests[regexTestWithSameMatchingRegexIndex].setCodeRegex(currentRegexTest.getCodeRegex());
@@ -121,9 +122,10 @@ class FileParser {
           continue;
         }
 
-        const currentRegexTest = currentRegexTests.find(
-          (regexTest) => regexTest.getMatchingRegexSource() === newRegexTest.getMatchingRegexSource(),
-        );
+        const newMatchingRegexSource = newRegexTest.getMatchingRegexSource();
+        const currentRegexTest = newMatchingRegexSource
+          ? currentRegexTests.find((regexTest) => regexTest.getMatchingRegexSource() === newMatchingRegexSource)
+          : undefined;
 
         if (currentRegexTest) {
           newRegexTest.setCodeRegex(currentRegexTest.getCodeRegex());

--- a/src/controllers/regex-test/RegexTest.ts
+++ b/src/controllers/regex-test/RegexTest.ts
@@ -72,14 +72,12 @@ class RegexTest {
         const flagsGroup = matchGroups.groups?.flags;
 
         let flags = flagsGroup?.replace('/', '') ?? '';
-        let matchingRegex = new RegExp(pattern, flags);
 
         if (!flags.includes(REQUIRED_FLAG)) {
           flags += REQUIRED_FLAG;
         }
 
-        matchingRegex = new RegExp(pattern, flags);
-        return matchingRegex;
+        return new RegExp(pattern, flags);
       }
     } catch (error) {
       if (error instanceof SyntaxError) {
@@ -121,15 +119,19 @@ class RegexTest {
     return this.matchingRegex;
   }
 
-  getMatchingRegexSource() {
+  getMatchingRegexSource(): string | undefined {
+    if (!this.matchingRegex) {
+      return undefined;
+    }
+
     const codeRegExp = this.getCodeRegExp();
     const hasIndicesFlag = codeRegExp?.hasIndices;
 
     const newRegexFlags = hasIndicesFlag
-      ? this.matchingRegex?.flags
-      : this.matchingRegex?.flags.replace(REQUIRED_FLAG, '');
+      ? this.matchingRegex.flags
+      : this.matchingRegex.flags.replace(REQUIRED_FLAG, '');
 
-    return `/${this.matchingRegex?.source}/${newRegexFlags}`;
+    return `/${this.matchingRegex.source}/${newRegexFlags}`;
   }
 
   getTestString() {

--- a/src/controllers/regex-test/RegexTest.ts
+++ b/src/controllers/regex-test/RegexTest.ts
@@ -26,6 +26,7 @@ class RegexTest {
   private testString: string;
   private startTestIndex: number;
   private codeRegex?: CodeRegex;
+  private error?: RegexSyntaxError;
 
   constructor({ regexPattern, regexLineIndex, testLines, startTestIndex, codeRegex }: RegexTestProps) {
     this.matchingRegex = this.transformStringToRegExp(regexPattern, regexLineIndex);
@@ -36,7 +37,7 @@ class RegexTest {
 
   test(): MatchResult[] {
     if (!this.matchingRegex) {
-      throw new Error('Regex not found');
+      return [];
     }
 
     const regexCopy = new RegExp(this.matchingRegex.source, this.matchingRegex.flags);
@@ -82,9 +83,13 @@ class RegexTest {
       }
     } catch (error) {
       if (error instanceof SyntaxError) {
-        throw new RegexSyntaxError(error.message, regexLineIndex);
+        this.error = new RegexSyntaxError(error.message, regexLineIndex);
       }
     }
+  }
+
+  getError(): RegexSyntaxError | undefined {
+    return this.error;
   }
 
   private processMatch(match: RegExpExecArray, lineStartIndex: number): MatchResult {

--- a/src/controllers/regex-test/RegexTest.ts
+++ b/src/controllers/regex-test/RegexTest.ts
@@ -65,7 +65,7 @@ class RegexTest {
 
   private transformStringToRegExp(regexPattern: string, regexLineIndex: number): RegExp | undefined {
     try {
-      const matchGroups = regexPattern.match(/^\/?(.*?)(?<flags>\/[gimuysvd]*)?$/);
+      const matchGroups = regexPattern.match(/^\/?(.*?)(?<flags>\/[a-zA-Z]*)?$/);
 
       if (matchGroups) {
         const [, pattern] = matchGroups;

--- a/src/controllers/regex-test/RegexTestFile.ts
+++ b/src/controllers/regex-test/RegexTestFile.ts
@@ -114,6 +114,14 @@ class RegexTestFile implements Disposable {
       const parsedRegexTests = FileParser.parseFileContent(fileContent, this.regexTests, codeRegex);
       this.regexTests = parsedRegexTests;
 
+      for (const regexTest of parsedRegexTests) {
+        const error = regexTest.getError();
+
+        if (error) {
+          diagnostics.push(this.createLineDiagnostic(document, error.line, error.message));
+        }
+      }
+
       return parsedRegexTests;
     } catch (error) {
       if (error instanceof Error) {
@@ -126,16 +134,16 @@ class RegexTestFile implements Disposable {
   }
 
   private handleError(error: Error, document: TextDocument): Diagnostic {
-    let documentErrorLine = document.lineAt(0).text;
-    let errorRange = new Range(0, 0, 0, documentErrorLine.length);
+    const errorLine = error instanceof RegexMatchFormatError || error instanceof RegexSyntaxError ? error.line : 0;
 
-    if (error instanceof RegexMatchFormatError || error instanceof RegexSyntaxError) {
-      documentErrorLine = document.lineAt(error.line).text;
-      errorRange = new Range(error.line, 0, error.line, documentErrorLine.length);
-    }
+    return this.createLineDiagnostic(document, errorLine, error.message);
+  }
 
-    const diagnosticError = this.diagnosticProvider.createErrorDiagnostic(errorRange, error.message);
-    return diagnosticError;
+  private createLineDiagnostic(document: TextDocument, line: number, message: string): Diagnostic {
+    const lineText = document.lineAt(line).text;
+    const range = new Range(line, 0, line, lineText.length);
+
+    return this.diagnosticProvider.createErrorDiagnostic(range, message);
   }
 
   handleTextDocumentChange(textEditor: TextEditor, codeRegex?: CodeRegex) {

--- a/src/providers/code-lenses/ApplyRegexCodeLensProvider.ts
+++ b/src/providers/code-lenses/ApplyRegexCodeLensProvider.ts
@@ -42,6 +42,10 @@ class ApplyRegexCodeLensProvider implements CodeLensProvider {
       }
 
       const matchingRegexSource = regexTest.getMatchingRegexSource();
+      if (!matchingRegexSource) {
+        continue;
+      }
+
       const targetRange = this.determineTargetRange(matchRanges, currentIndex, matchingRegexSource);
       const command = {
         title: 'Apply Regex to Code',

--- a/src/tests/unit/file-parser/file-parser.test.ts
+++ b/src/tests/unit/file-parser/file-parser.test.ts
@@ -59,19 +59,18 @@ describe('File Parser', () => {
     expect(regexTests[0].getStartTestIndex()).toBe(15);
   });
 
-  it('should parse regex test with an error if the matching regex is invalid', () => {
+  it('should return the block with its syntax error captured when the only regex is invalid', () => {
     const fileContent = '/(?/gm\n---\nbb9abb\n---';
 
-    try {
-      FileParser.parseFileContent(fileContent, []);
-      expect.unreachable('Expected to throw an error');
-    } catch (error) {
-      expect(error).toBeInstanceOf(RegexSyntaxError);
+    const regexTests = FileParser.parseFileContent(fileContent, []);
+    expect(regexTests).toHaveLength(1);
 
-      const regexMatchFormatError = error as RegexSyntaxError;
-      expect(regexMatchFormatError.message).toContain('Invalid regular expression');
-      expect(regexMatchFormatError.line).toBe(0);
-    }
+    const error = regexTests[0].getError();
+    expect(error).toBeInstanceOf(RegexSyntaxError);
+    expect(error!.message).toContain('Invalid regular expression');
+    expect(error!.line).toBe(0);
+
+    expect(regexTests[0].test()).toEqual([]);
   });
 
   it('should throw error if the file content does not contain the test area delimiter', () => {
@@ -150,19 +149,37 @@ describe('File Parser', () => {
       }
     });
 
-    it('should parse correctly if the second matching regex is invalid', () => {
-      const fileContent = '/[0-9]/gm\n---\nbb9abb\n---\n/[0-9](/gm\n---\n9\n---';
+    it('should keep the second block valid when the first block regex is invalid', () => {
+      const fileContent = '/[0-9](/gm\n---\nbb9abb\n---\n/[0-9]/gm\n---\n9\n---';
 
-      try {
-        FileParser.parseFileContent(fileContent, []);
-        expect.unreachable('Expected to throw an error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(RegexSyntaxError);
+      const regexTests = FileParser.parseFileContent(fileContent, []);
+      expect(regexTests).toHaveLength(2);
 
-        const regexMatchFormatError = error as RegexSyntaxError;
-        expect(regexMatchFormatError.message).toContain('Invalid regular expression');
-        expect(regexMatchFormatError.line).toBe(4);
-      }
+      const firstError = regexTests[0].getError();
+      expect(firstError).toBeInstanceOf(RegexSyntaxError);
+      expect(firstError!.line).toBe(0);
+      expect(regexTests[0].test()).toEqual([]);
+
+      expect(regexTests[1].getError()).toBeUndefined();
+      const secondMatches = regexTests[1].test();
+      expect(secondMatches).toHaveLength(1);
+      expect(secondMatches[0].substring).toBe('9');
+    });
+
+    it('should keep the first block valid when the second block regex is invalid', () => {
+      const fileContent = '/[0-9]/gm\n---\n9\n---\n/[0-9](/gm\n---\nbb9abb\n---';
+
+      const regexTests = FileParser.parseFileContent(fileContent, []);
+      expect(regexTests).toHaveLength(2);
+
+      expect(regexTests[0].getError()).toBeUndefined();
+      const firstMatches = regexTests[0].test();
+      expect(firstMatches).toHaveLength(1);
+      expect(firstMatches[0].substring).toBe('9');
+
+      const secondError = regexTests[1].getError();
+      expect(secondError).toBeInstanceOf(RegexSyntaxError);
+      expect(secondError!.line).toBe(4);
     });
 
     it('should parse multiple regex tests correctly', () => {
@@ -208,16 +225,15 @@ describe('File Parser', () => {
     it('should parse multiple regex tests correctly, if there is a regex with an error', () => {
       const fileContent = '/[0-9]/gm\n---\ntest1\ntest2\n---\n/[0-9](/gm\n---\n9\n---';
 
-      try {
-        FileParser.parseFileContent(fileContent, []);
-        expect.unreachable('Expected to throw an error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(RegexSyntaxError);
+      const regexTests = FileParser.parseFileContent(fileContent, []);
+      expect(regexTests).toHaveLength(2);
 
-        const regexMatchFormatError = error as RegexSyntaxError;
-        expect(regexMatchFormatError.message).toContain('Invalid regular expression');
-        expect(regexMatchFormatError.line).toBe(5);
-      }
+      expect(regexTests[0].getError()).toBeUndefined();
+
+      const secondError = regexTests[1].getError();
+      expect(secondError).toBeInstanceOf(RegexSyntaxError);
+      expect(secondError!.message).toContain('Invalid regular expression');
+      expect(secondError!.line).toBe(5);
     });
 
     it('should parse multiple regex tests correctly, if there are empty lines between tests', () => {

--- a/src/tests/unit/regex-test.test.ts
+++ b/src/tests/unit/regex-test.test.ts
@@ -202,7 +202,7 @@ describe('Regex Test', () => {
     expect(matchResult[0].groupRanges).toBeUndefined();
   });
 
-  it('should throw an error, if the regex is invalid', () => {
+  it('should expose the syntax error via getError(), if the regex is invalid', () => {
     const regexTestProps: RegexTestProps = {
       regexPattern: '/(?/gm',
       regexLineIndex: 6,
@@ -210,16 +210,36 @@ describe('Regex Test', () => {
       startTestIndex: 0,
     };
 
-    try {
-      new RegexTest(regexTestProps);
-      expect.unreachable('Expected to throw an error');
-    } catch (error) {
-      expect(error).toBeInstanceOf(RegexSyntaxError);
+    const regexTest = new RegexTest(regexTestProps);
+    const error = regexTest.getError();
 
-      const regexMatchFormatError = error as RegexSyntaxError;
-      expect(regexMatchFormatError.message).toContain('Invalid regular expression');
-      expect(regexMatchFormatError.line).toBe(regexTestProps.regexLineIndex);
-    }
+    expect(error).toBeInstanceOf(RegexSyntaxError);
+    expect(error!.message).toContain('Invalid regular expression');
+    expect(error!.line).toBe(6);
+  });
+
+  it('should return an empty match array from test(), if the regex is invalid', () => {
+    const regexTestProps: RegexTestProps = {
+      regexPattern: '/(?/gm',
+      regexLineIndex: 6,
+      testLines: ['9ab', '8a', '7A'],
+      startTestIndex: 0,
+    };
+
+    const regexTest = new RegexTest(regexTestProps);
+    expect(regexTest.test()).toEqual([]);
+  });
+
+  it('should return undefined from getError(), if the regex is valid', () => {
+    const regexTestProps: RegexTestProps = {
+      regexPattern: '/[0-9]a/g',
+      regexLineIndex: 0,
+      testLines: ['bbb9abbbb'],
+      startTestIndex: 0,
+    };
+
+    const regexTest = new RegexTest(regexTestProps);
+    expect(regexTest.getError()).toBeUndefined();
   });
 
   describe('Capturing Groups', () => {

--- a/src/tests/unit/regex-test.test.ts
+++ b/src/tests/unit/regex-test.test.ts
@@ -218,6 +218,40 @@ describe('Regex Test', () => {
     expect(error!.line).toBe(6);
   });
 
+  it('should expose the syntax error via getError(), if the regex has an unknown flag', () => {
+    const regexTestProps: RegexTestProps = {
+      regexPattern: '/[0-9]+a+/c',
+      regexLineIndex: 3,
+      testLines: ['123aaa'],
+      startTestIndex: 0,
+    };
+
+    const regexTest = new RegexTest(regexTestProps);
+    const error = regexTest.getError();
+
+    expect(error).toBeInstanceOf(RegexSyntaxError);
+    expect(error!.message).toContain('Invalid flags');
+    expect(error!.line).toBe(3);
+    expect(regexTest.test()).toEqual([]);
+  });
+
+  it('should keep a literal forward slash in the pattern and parse trailing flags, if the pattern contains a slash', () => {
+    const regexTestProps: RegexTestProps = {
+      regexPattern: '/a\\/b/g',
+      regexLineIndex: 0,
+      testLines: ['xa/byy'],
+      startTestIndex: 0,
+    };
+
+    const regexTest = new RegexTest(regexTestProps);
+
+    expect(regexTest.getError()).toBeUndefined();
+
+    const matchResult = regexTest.test();
+    expect(matchResult.length).toBe(1);
+    expect(matchResult[0].substring).toBe('a/b');
+  });
+
   it('should return an empty match array from test(), if the regex is invalid', () => {
     const regexTestProps: RegexTestProps = {
       regexPattern: '/(?/gm',


### PR DESCRIPTION
<!-- You could omit the sections that are not applicable to the changes. -->

### Features <!-- Describe the features that you have added -->

- Capture invalid-regex syntax error per block instead of throwing and killing all highlights.

### Fixes <!-- Describe the bug fixes that you have made -->

- Detect unknown regex flags and flag them as errors instead of silently folding them into the pattern.

### Tests <!-- Describe the tests that you have added or updated -->

- Add cases for per-block syntax errors, scoped diagnostics, and unknown flags.

### Visual Changes <!-- Add screenshots, videos or GIFs to show the visual changes -->
#### Before
<img width="602" height="379" alt="image" src="https://github.com/user-attachments/assets/ec32afb7-07e5-49cc-9db9-12399ce99cc7" />

#### After
<img width="602" height="379" alt="image" src="https://github.com/user-attachments/assets/cc183ce7-130d-4ae3-885b-9ffe2e0f5c6c" />

---

Closes #107.

---

### Development Checklist

<!-- Check each of the following items before submitting the pull request. You can omit items that are not applicable to the changes. -->

- [x] I have tested the changes locally and unit and integration tests are passing.
- [x] I have added new tests and/or updated existing tests to cover the changes.
- [x] I have updated the documentations in both the [README.md](README.md) and [CHANGELOG.md](CHANGELOG.md) with the details of the changes.
